### PR TITLE
Bug fix and code improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,18 +40,17 @@ jobs:
       - name: Build (Release)
         run: dotnet build . --configuration Release --no-restore -p:Version=$GitVersion_SemVer
 
-      - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v3.1.0
-        with:
-          path: ./bin/Release/net6.0/XPRising.dll
-
       - name: GH Release
         uses: softprops/action-gh-release@v1
         if: github.event_name == 'push'
         with:
           body: Automatic pre-release of ${{ env.GitVersion_SemVer }} for ${{ env.GitVersion_ShortSha }}
           name: v${{ env.GitVersion_SemVer }}
-          files: ./bin/Release/net6.0/XPRising.dll
           fail_on_unmatched_files: true
           prerelease: true
           tag_name: v${{ env.GitVersion_SemVer }}
+          files: |
+            ./bin/Release/net6.0/XPRising.dll
+            LICENSE.txt
+            CHANGELOG.md
+            icon.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+﻿# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+- `Added` for new features.
+- `Changed` for changes in existing functionality.
+- `Deprecated` for soon-to-be removed features.
+- `Removed` for now removed features.
+- `Fixed` for any bug fixes.
+- `Security` in case of vulnerabilities.
+
+## [Pre-release]
+
+### Added
+
+- Added support to load starting XP for player characters directly from the server configuration options.
+Server admins can now set lowest level via this setting.
+- Improved auto-save config to aid admin configuration 
+
+### Fixed
+
+- `group add` command can now be successfully run
+- Fixed bug with attempting to read Weapon mastery data from internal database
+- Bloodine mastery logging now correctly only happens if the player has enabled it
+- Fixed auto-saving to correctly only log that it is saving when it is saving
+- Stopped start-up logs from complaining about debug functions not provided to players
+- Fixed white text colouring in messages to players
+- Fixed saving alliance/custom group user preferences
+
+### Changed
+
+- Added this ChangeLog
+- Updated documentation for clarity
+
+## [0.1.1] - 2024-05-17
+
+### Added
+
+- Added a new command to temporarily bypass the lvl 20 requirement for the "Getting ready for the Hunt" journal
+
+### Fixed
+
+- Fix crash when trying to determine nearby allies (for group xp/heat)
+- Fixed bloodline mastery logging to only log when you have it enabled
+
+### Changed
+
+- Changed the mod icon
+- Linked the other documentation files to README.md
+
+## [0.1.0] - 2024-05-16
+
+### Changed
+
+- Changed name to XPRising
+- 0.1.0 Initial update for VRising 1.0

--- a/Commands/AllianceCommands.cs
+++ b/Commands/AllianceCommands.cs
@@ -1,6 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using ProjectM;
-using ProjectM.Network;
 using Unity.Entities;
 using VampireCommandFramework;
 using XPRising.Models;
@@ -27,16 +27,16 @@ public static class AllianceCommands
             groupDetails = Cache.AlliancePlayerGroups[currentGroupId].PrintAllies();
         }
         
-        var prefs = Database.AlliancePlayerPrefs[playerCharacter];
+        var alliancePreferences = Database.AlliancePlayerPrefs[playerCharacter];
 
         var pendingInviteDetails = "You currently have no pending group invites.";
-        if (Cache.AlliancePendingInvites.TryGetValue(playerCharacter, out var pendingInvites))
+        if (Cache.AlliancePendingInvites.TryGetValue(playerCharacter, out var pendingInvites) && pendingInvites.Count > 0)
         {
             var invitesList = pendingInvites.OrderBy(x => x.InvitedAt).Select((invite, i) => $"{i}: {invite.InviterName} at {invite.InvitedAt}");
             pendingInviteDetails = $"Current invites:\n{string.Join("\n", invitesList)}";
         }
         
-        ctx.Reply($"{pendingInviteDetails}\n{prefs.ToString()}\n{groupDetails}");
+        ctx.Reply($"{pendingInviteDetails}\n\nPreferences:\n{alliancePreferences.ToString()}\n\n{groupDetails}");
     }
 
     [Command("group ignore", "gi", "", "Toggles ignoring group invites for yourself.", adminOnly: false)]
@@ -78,6 +78,10 @@ public static class AllianceCommands
             {
                 throw ctx.Error($"Could not find specified player \"{playerName}\".");
             }
+            else if (targetEntity.Equals(playerCharacter))
+            {
+                throw ctx.Error($"You cannot add yourself to your group");
+            }
             
             newPlayerGroup = new Alliance.PlayerGroup();
             newPlayerGroup.Allies.Add(targetEntity);
@@ -88,35 +92,37 @@ public static class AllianceCommands
 
             if (newPlayerGroup.Allies.Count < 2)
             {
-                throw ctx.Error($"Could not detect any other nearby players to make a group with.");
+                ctx.Reply($"No nearby players detected to make a group with.");
+                return;
             }
         }
 
-        var groupId = Cache.AlliancePlayerToGroupId[playerCharacter];
+        if (!Cache.AlliancePlayerToGroupId.TryGetValue(playerCharacter, out var groupId))
+        {
+            groupId = Guid.NewGuid();
+            
+            // Create a new group and ensure that we are in it.
+            Cache.AlliancePlayerToGroupId[playerCharacter] = groupId;
+            Cache.AlliancePlayerGroups[groupId] = new Alliance.PlayerGroup() { Allies = { playerCharacter } };
+        }
 
         var currentGroup = Cache.AlliancePlayerGroups[groupId];
-        // Add ourselves to the group. This will not cause a duplication because it is a set.
-        // It ensures that it will correctly skip trying to run checks to see if we can add ourselves.
-        currentGroup.Allies.Add(playerCharacter);
         foreach (var newAlly in newPlayerGroup.Allies)
         {
+            var allyPlayerCharacter = _entityManager.GetComponentData<PlayerCharacter>(newAlly);
+            var allyName = allyPlayerCharacter.Name.ToString();
+            
             if (currentGroup.Allies.Contains(newAlly))
             {
                 // Player already in current group, skipping.
+                ctx.Reply($"{allyName} is already in your group.");
                 continue;
             }
-            var allyUser = _entityManager.GetComponentData<User>(newAlly);
-            var allyName = allyUser.CharacterName.ToString();
 
             var newAllyAlliancePrefs = Database.AlliancePlayerPrefs[newAlly];
             if (newAllyAlliancePrefs.IgnoringInvites)
             {
                 ctx.Reply($"{allyName} is currently ignoring group invites. Ask them to change this setting before attempting to make a group.");
-                continue;
-            }
-            else if (Cache.AlliancePlayerToGroupId.ContainsKey(newAlly))
-            {
-                ctx.Reply($"{allyName} is already in a group. They should leave their current one first.");
                 continue;
             }
             else if (Cache.AlliancePlayerToGroupId.ContainsKey(newAlly))
@@ -139,8 +145,7 @@ public static class AllianceCommands
                 $"Type \".group yes\" to accept or \".group no\" to reject." :
                 $"Type \".group yes {inviteId}\" to accept or \".group no {inviteId}\" to reject.";
             
-            var allyUserEntity = _entityManager.GetComponentData<PlayerCharacter>(newAlly).UserEntity;
-            Output.SendLore(allyUserEntity, $"{ctx.User.CharacterName} has invited you to join their group! {inviteString} No further messages will be sent about this invite.");
+            Output.SendLore(allyPlayerCharacter.UserEntity, $"{ctx.User.CharacterName} has invited you to join their group! {inviteString} No further messages will be sent about this invite.");
         }
     }
 
@@ -179,7 +184,7 @@ public static class AllianceCommands
         {
             if (ally == playerCharacter)
             {
-                ctx.Reply($"You have successfully joined the group! Other members: {group}");
+                ctx.Reply($"You have successfully joined the group!\n{group.PrintAllies()}");
             }
             else
             {

--- a/Commands/MasteryCommands.cs
+++ b/Commands/MasteryCommands.cs
@@ -71,7 +71,7 @@ namespace XPRising.Commands {
             var effectiveness = WeaponMasterySystem.EffectivenessSubSystemEnabled ? wdType.Effectiveness : 1;
             var growth = wdType.Growth;
             
-            var statData = Database.MasteryStatConfig.GetValueOrDefault(type).Select(config =>
+            var statData = Database.MasteryStatConfig[type].Select(config =>
             {
                 var val = Helper.CalcBuffValue(mastery, effectiveness, config.rate, config.type);
                 

--- a/Commands/WantedCommands.cs
+++ b/Commands/WantedCommands.cs
@@ -12,153 +12,151 @@ using XPRising.Systems;
 using XPRising.Utils;
 using Faction = XPRising.Utils.Prefabs.Faction;
 using LogSystem = XPRising.Plugin.LogSystem;
-using Prefabs_Faction = XPRising.Utils.Prefabs.Faction;
 
-namespace XPRising.Commands
-{
-    [CommandGroup("wanted", "w")]
-    public static class WantedCommands {
-        private static void SendFactionWantedMessage(PlayerHeatData heatData, Entity userEntity, bool userIsAdmin) {
-            bool isWanted = false;
-            foreach (Prefabs_Faction faction in FactionHeat.ActiveFactions) {
-                var heat = heatData.heat[faction];
-                // Don't display this faction's heat level if the wanted level is 0.
-                if (heat.level < FactionHeat.HeatLevels[0] && !userIsAdmin) continue;
-                isWanted = true;
-                
-                Output.SendLore(userEntity, FactionHeat.GetFactionStatus(faction, heat.level));
-                
-                if (userIsAdmin && DebugLoggingConfig.IsLogging(Plugin.LogSystem.Wanted))
-                {
-                    var sinceAmbush = DateTime.Now - heat.lastAmbushed;
-                    var nextAmbush = Math.Max((int)(WantedSystem.ambush_interval - sinceAmbush.TotalSeconds), 0);
-                    Output.SendLore(
-                        userEntity,
-                        $"Level: <color={Output.White}>{heat.level:D}</color> " +
-                        $"Possible ambush in <color={Color.White}>{nextAmbush:D}</color>s " +
-                        $"Chance: <color={Color.White}>{WantedSystem.ambush_chance:D}</color>%");
-                }
-            }
+namespace XPRising.Commands;
 
-            if (!isWanted) {
-                Output.SendLore(userEntity, "No active wanted levels");
+[CommandGroup("wanted", "w")]
+public static class WantedCommands {
+    private static void SendFactionWantedMessage(PlayerHeatData heatData, Entity userEntity, bool userIsAdmin) {
+        bool isWanted = false;
+        foreach (Faction faction in FactionHeat.ActiveFactions) {
+            var heat = heatData.heat[faction];
+            // Don't display this faction's heat level if the wanted level is 0.
+            if (heat.level < FactionHeat.HeatLevels[0] && !userIsAdmin) continue;
+            isWanted = true;
+            
+            Output.SendLore(userEntity, FactionHeat.GetFactionStatus(faction, heat.level));
+            
+            if (userIsAdmin && DebugLoggingConfig.IsLogging(LogSystem.Wanted))
+            {
+                var sinceAmbush = DateTime.Now - heat.lastAmbushed;
+                var nextAmbush = Math.Max((int)(WantedSystem.ambush_interval - sinceAmbush.TotalSeconds), 0);
+                Output.SendLore(
+                    userEntity,
+                    $"Level: <color={Output.White}>{heat.level:D}</color> " +
+                    $"Possible ambush in <color={Color.White}>{nextAmbush:D}</color>s " +
+                    $"Chance: <color={Color.White}>{WantedSystem.ambush_chance:D}</color>%");
             }
+        }
+
+        if (!isWanted) {
+            Output.SendLore(userEntity, "No active wanted levels");
+        }
+    }
+    
+    [Command("get","g", "", "Shows your current wanted level", adminOnly: false)]
+    public static void GetWanted(ChatCommandContext ctx){
+        if (!Plugin.WantedSystemActive){
+            ctx.Reply("Wanted system is not enabled.");
+            return;
+        }
+        var userEntity = ctx.Event.SenderUserEntity;
+        
+        var heatData = WantedSystem.GetPlayerHeat(userEntity);
+        SendFactionWantedMessage(heatData, userEntity, ctx.IsAdmin);
+    }
+
+    [Command("set","s", "<name> <faction> <value>", "Sets the current wanted level", adminOnly: true)]
+    public static void SetWanted(ChatCommandContext ctx, string name, string faction, int value) {
+        var contextUserEntity = ctx.Event.SenderUserEntity;
+            
+        if (!Helper.FindPlayer(name, true, out _, out var targetUserEntity))
+        {
+            ctx.Reply($"Could not find specified player \"{name}\".");
+            return;
+        }
+
+        if (!Enum.TryParse(faction, true, out Faction heatFaction) || !FactionHeat.ActiveFactions.Contains(heatFaction)) {
+            var supportedFactions = String.Join(", ", FactionHeat.ActiveFactions);
+            ctx.Reply($"Faction not yet supported. Supported factions: {supportedFactions}");
+            return;
+        }
+
+        var heatLevel = value == 0
+            ? 0
+            : FactionHeat.HeatLevels[Math.Clamp(value - 1, 0, FactionHeat.HeatLevels.Length - 1)] + 10;
+
+        // Set wanted level and reset last ambushed so the user can be ambushed from now (ie, greater than ambush_interval seconds ago) 
+        var updatedHeatData = WantedSystem.SetPlayerHeat(
+            targetUserEntity,
+            heatFaction,
+            heatLevel,
+            DateTime.Now - TimeSpan.FromSeconds(WantedSystem.ambush_interval + 1));
+            
+        ctx.Reply($"Player \"{name}\" wanted value changed.");
+        SendFactionWantedMessage(updatedHeatData, contextUserEntity, ctx.IsAdmin);
+        if (!targetUserEntity.Equals(contextUserEntity)) {
+            SendFactionWantedMessage(updatedHeatData, targetUserEntity, false);
+        }
+    }
+    
+    [Command("log", "l", "", "Toggle logging of heat data.", adminOnly: false)]
+    public static void LogWanted(ChatCommandContext ctx){
+        if (!Plugin.WantedSystemActive){
+            ctx.Reply("Wanted system is not enabled.");
+            return;
+        }
+
+        var steamID = ctx.User.PlatformId;
+        var loggingData = Database.PlayerLogConfig[steamID];
+        loggingData.LoggingWanted = !loggingData.LoggingWanted;
+        ctx.Reply(loggingData.LoggingWanted
+            ? "Heat levels now being logged."
+            : "Heat levels no longer being logged.");
+        Database.PlayerLogConfig[steamID] = loggingData;
+    }
+
+    [Command("trigger","t", "<name>", "Triggers the ambush check for the given user", adminOnly: true)]
+    public static void TriggerAmbush(ChatCommandContext ctx, string name) {
+        if (!Helper.FindPlayer(name, true, out var playerEntity, out _))
+        {
+            ctx.Reply($"Could not find specified player \"{name}\".");
+            return;
         }
         
-        [Command("get","g", "", "Shows your current wanted level", adminOnly: false)]
-        public static void GetWanted(ChatCommandContext ctx){
-            if (!Plugin.WantedSystemActive){
-                ctx.Reply("Wanted system is not enabled.");
-                return;
-            }
-            var userEntity = ctx.Event.SenderUserEntity;
-            
-            var heatData = WantedSystem.GetPlayerHeat(userEntity);
-            SendFactionWantedMessage(heatData, userEntity, ctx.IsAdmin);
-        }
+        WantedSystem.CheckForAmbush(playerEntity);
+        ctx.Reply($"Successfully triggered ambush check for \"{name}\"");
+    }
 
-        [Command("set","s", "<name> <faction> <value>", "Sets the current wanted level", adminOnly: true)]
-        public static void SetWanted(ChatCommandContext ctx, string name, string faction, int value) {
-            var contextUserEntity = ctx.Event.SenderUserEntity;
+    [Command("fixminions", "fm", "", "Remove broken gloomrot technician units", adminOnly: true)]
+    public static void FixGloomrotMinions(ChatCommandContext ctx) {
+        if (!ctx.Event.User.IsAdmin) return;
+
+        var hasErrors = false;
+        var removedCount = 0;
+
+        var query = Plugin.Server.EntityManager.CreateEntityQuery(new EntityQueryDesc()
+        {
+            All = new ComponentType[]
+            {
+                ComponentType.ReadOnly<Minion>()
+            },
+            Options = EntityQueryOptions.IncludeDisabled
+        });
+        foreach (var entity in query.ToEntityArray(Allocator.Temp)) {
+            try {
+                var unitName = DebugTool.GetPrefabName(Helper.GetPrefabGUID(entity));
+                // Note that the "broken" units differ from "working" units only by the broken ones missing the
+                // "PathRequestSolveDebugBuffer [B]" component. Ideally, we would only destroy minions missing the
+                // component, but we can't test for this case by any means other than checking the string generated
+                // by Plugin.Server.EntityManager.Debug.GetEntityInfo(entity). We can't test for this case as the
+                // GetBuffer or HasBuffer commands fail with an AOT code exception.
+                Plugin.Log(LogSystem.Wanted, LogLevel.Info, $"destroying minion {unitName}");
                 
-            if (!Helper.FindPlayer(name, true, out _, out var targetUserEntity))
-            {
-                ctx.Reply($"Could not find specified player \"{name}\".");
-                return;
+                DestroyUtility.CreateDestroyEvent(Plugin.Server.EntityManager, entity, DestroyReason.Default, DestroyDebugReason.None);
+                DestroyUtility.Destroy(Plugin.Server.EntityManager, entity);
+                removedCount++;
             }
-
-            if (!Enum.TryParse(faction, true, out Prefabs_Faction heatFaction) || !FactionHeat.ActiveFactions.Contains(heatFaction)) {
-                var supportedFactions = String.Join(", ", FactionHeat.ActiveFactions);
-                ctx.Reply($"Faction not yet supported. Supported factions: {supportedFactions}");
-                return;
-            }
-
-            var heatLevel = value == 0
-                ? 0
-                : FactionHeat.HeatLevels[Math.Clamp(value - 1, 0, FactionHeat.HeatLevels.Length - 1)] + 10;
-
-            // Set wanted level and reset last ambushed so the user can be ambushed from now (ie, greater than ambush_interval seconds ago) 
-            var updatedHeatData = WantedSystem.SetPlayerHeat(
-                targetUserEntity,
-                heatFaction,
-                heatLevel,
-                DateTime.Now - TimeSpan.FromSeconds(WantedSystem.ambush_interval + 1));
-                
-            ctx.Reply($"Player \"{name}\" wanted value changed.");
-            SendFactionWantedMessage(updatedHeatData, contextUserEntity, ctx.IsAdmin);
-            if (!targetUserEntity.Equals(contextUserEntity)) {
-                SendFactionWantedMessage(updatedHeatData, targetUserEntity, false);
+            catch (Exception e) {
+                Plugin.Log(LogSystem.Wanted, LogLevel.Info, "error doing test other: " + e.Message);
+                hasErrors = true;
             }
         }
-        
-        [Command("log", "l", "", "Toggle logging of heat data.", adminOnly: false)]
-        public static void LogWanted(ChatCommandContext ctx){
-            if (!Plugin.WantedSystemActive){
-                ctx.Reply("Wanted system is not enabled.");
-                return;
-            }
 
-            var steamID = ctx.User.PlatformId;
-            var loggingData = Database.PlayerLogConfig[steamID];
-            loggingData.LoggingWanted = !loggingData.LoggingWanted;
-            ctx.Reply(loggingData.LoggingWanted
-                ? "Heat levels now being logged."
-                : "Heat levels no longer being logged.");
-            Database.PlayerLogConfig[steamID] = loggingData;
-        }
-
-        [Command("trigger","t", "<name>", "Triggers the ambush check for the given user", adminOnly: true)]
-        public static void TriggerAmbush(ChatCommandContext ctx, string name) {
-            if (!Helper.FindPlayer(name, true, out var playerEntity, out _))
-            {
-                ctx.Reply($"Could not find specified player \"{name}\".");
-                return;
-            }
-            
-            WantedSystem.CheckForAmbush(playerEntity);
-            ctx.Reply($"Successfully triggered ambush check for \"{name}\"");
-        }
-
-        [Command("fixminions", "fm", "", "Remove broken gloomrot technician units", adminOnly: true)]
-        public static void FixGloomrotMinions(ChatCommandContext ctx) {
-            if (!ctx.Event.User.IsAdmin) return;
-
-            var hasErrors = false;
-            var removedCount = 0;
-
-            var query = Plugin.Server.EntityManager.CreateEntityQuery(new EntityQueryDesc()
-            {
-                All = new ComponentType[]
-                {
-                    ComponentType.ReadOnly<Minion>()
-                },
-                Options = EntityQueryOptions.IncludeDisabled
-            });
-            foreach (var entity in query.ToEntityArray(Allocator.Temp)) {
-                try {
-                    var unitName = DebugTool.GetPrefabName(Helper.GetPrefabGUID(entity));
-                    // Note that the "broken" units differ from "working" units only by the broken ones missing the
-                    // "PathRequestSolveDebugBuffer [B]" component. Ideally, we would only destroy minions missing the
-                    // component, but we can't test for this case by any means other than checking the string generated
-                    // by Plugin.Server.EntityManager.Debug.GetEntityInfo(entity). We can't test for this case as the
-                    // GetBuffer or HasBuffer commands fail with an AOT code exception.
-                    Plugin.Log(Plugin.LogSystem.Wanted, LogLevel.Info, $"destroying minion {unitName}");
-                    
-                    DestroyUtility.CreateDestroyEvent(Plugin.Server.EntityManager, entity, DestroyReason.Default, DestroyDebugReason.None);
-                    DestroyUtility.Destroy(Plugin.Server.EntityManager, entity);
-                    removedCount++;
-                }
-                catch (Exception e) {
-                    Plugin.Log(Plugin.LogSystem.Wanted, LogLevel.Info, "error doing test other: " + e.Message);
-                    hasErrors = true;
-                }
-            }
-
-            if (hasErrors) {
-                ctx.Reply($"Finished with errors (check logs). Removed {removedCount} units.");
-            } else {
-                ctx.Reply($"Finished successfully. Removed {removedCount} units.");
-            }
+        if (hasErrors) {
+            ctx.Reply($"Finished with errors (check logs). Removed {removedCount} units.");
+        } else {
+            ctx.Reply($"Finished successfully. Removed {removedCount} units.");
         }
     }
 }

--- a/Commands/WantedCommands.cs
+++ b/Commands/WantedCommands.cs
@@ -136,7 +136,7 @@ namespace XPRising.Commands
             });
             foreach (var entity in query.ToEntityArray(Allocator.Temp)) {
                 try {
-                    var unitName = Helper.GetPrefabName(Helper.GetPrefabGUID(entity));
+                    var unitName = DebugTool.GetPrefabName(Helper.GetPrefabGUID(entity));
                     // Note that the "broken" units differ from "working" units only by the broken ones missing the
                     // "PathRequestSolveDebugBuffer [B]" component. Ideally, we would only destroy minions missing the
                     // component, but we can't test for this case by any means other than checking the string generated

--- a/Documentation.md
+++ b/Documentation.md
@@ -1,43 +1,29 @@
 ﻿## Experience System
-<details>
-<summary>Experience System</summary>
-Disable the VRising Gear Level system and replace it with a traditional RPG experience system,\
+
+Disable the VRising Gear Level system and replace it with a traditional RPG experience system,
 complete with exp sharing between clan members or other players designated as allies.
-</details>
 
 Currently, your HP will increase by a minor amount each level.
 
-#### Clans and Groups and XP sharing
-Killing with other vampires can provide group XP and wanted levels.
+## Weapon Mastery System
 <details>
 
-A vampire is considered in your group if they are in your clan or if you use the `group` commands to create a group with
-them. A group will only share XP if the members are close enough to each other, governed by the `Ally Max Distance` config.
-
-<summary>Group XP options</summary>
-Group XP is awarded based on the ratio of the average group level to the sum of the group level. It is then multiplied
-by a bonus value `( 1.2^(group size - 1) )`, up to a maximum of `1.5`.
-</details>
-
-## Mastery System
-<details>
-<summary>Mastery System</summary>
-> ### Weapon Mastery
+### Weapon Mastery
 Mastering a weapon will now progressively give extra bonuses to the character's stats.
 Weapon mastery will increase when the weapon is used to kill a creature, and while in combat to a maximum of 60 seconds at 0.001%/Sec.
 Spell mastery can only increase and take effect when no weapon is equipped, unless changed in the configuration options.
 
-> ### Mastery Decay
+### Mastery Decay
 When the vampire goes offline, all their weapon mastery will continuously decay until they come back online.
 
-> ### Effectiveness System
+### Effectiveness System
 Effectiveness acts as a multiplier for the weapon mastery. The initial effectiveness starts at 100%.
 When weapon mastery is reset using ".mastery reset <type>", the current mastery level is added to effectiveness and then is set to 0%.
-As the vampire then increases in weapon mastery, the effective weapon mastery is mastery * effectiveness.
+As the vampire then increases in weapon mastery, the effective weapon mastery is `mastery * effectiveness`.
 
 Effectiveness is specific for each weapon.
 
-> ### Growth System
+### Growth System
 The growth system is used to determine how fast mastery can be gained at higher levels of effectiveness.
 This means that higher effectiveness will slow to mastery gain (at 1, 200% effectiveness gives a mastery growth rate of 50%).
 Config supports modifying the rate at which this growth slows. Set growth per effectiveness to 0 to have no change in growth. Higher numbers make the growth drop off slower.
@@ -47,30 +33,30 @@ This is only relevant if the effectiveness system is turned on.
 
 </details>
 
-## Bloodline System
+## Bloodline Mastery System
 <details>
-<summary>Bloodline System</summary>
-> ### Bloodlines
+
+### Bloodlines
 Killing enemies while you have a blood type will progress the mastery of your bloodline.
 As your bloodline grows in mastery it will provide scaling benefits to your stats.
-By default merciless bloodlines are enabled, which means to progress your bloodline's mastery\
+`Merciless bloodlines` are enabled by default, which means to progress your bloodline's mastery
 you need to kill a target with same blood type AND it needs to be blood of higher quality than your bloodline's mastery.
 V Blood always provides progress even in merciless mode.
 
 Bloodline mastery for blood types that don't match your current blood will still be applied at a greatly reduced amount.
 The command is .bloodline or .bl
 
-> ### Bloodline Decay
+### Mastery Decay
 When the vampire goes offline, all their bloodline mastery will continuously decay until they come back online.
 
-> ### Effectiveness System
+### Effectiveness System
 Effectiveness acts as a multiplier for the bloodline mastery. The initial effectiveness starts at 100%.
 When bloodline mastery is reset using ".bloodline reset <type>", the current mastery level is added to effectiveness and then is set to 0%.
-As the vampire then increases in bloodline mastery, the effective bloodline mastery is mastery * effectiveness.
+As the vampire then increases in bloodline mastery, the effective bloodline mastery is `mastery * effectiveness`.
 
 Effectiveness is specific for each bloodline.
 
-> ### Growth System
+### Growth System
 The growth system is used to determine how fast mastery can be gained at higher levels of effectiveness.
 This means that higher effectiveness will slow to mastery gain (at 1, 200% effectiveness gives a mastery growth rate of 50%).
 Config supports modifying the rate at which this growth slows. Set growth per effectiveness to 0 to have no change in growth. Higher numbers make the growth drop off slower.
@@ -82,17 +68,16 @@ This is only relevant if the effectiveness system is turned on.
 
 ## Wanted System
 <details>
-<summary>Heat System</summary>
-A new system where every NPC you kill contributes to a wanted level system,\
-if you kill too many NPCs from that faction, eventually your wanted level will rise higher and higher.\
+A system where every NPC you kill contributes to a wanted level system. As you kill more NPCs from a faction,
+your wanted level will rise higher and higher.
 
-The higher your wanted level is, a more difficult squad of ambushers will be sent by that faction to kill you.\
-Wanted level will eventually cooldown the longer you go without killing NPCs from that faction,\
-space your kills so you don't get hunted by an extremely elite group of assassins.\
+As your wanted level increases, more difficult squads of ambushers will be sent by that faction to kill you.
+Wanted levels for will eventually cooldown the longer you go without killing NPCs from a faction, so space out
+your kills to ensure you don't get hunted by an extremely elite group of assassins.
 
 Another way of lowering your wanted level is to kill Vampire Hunters.
 
-Otherwise, if you are dead for any reason at all, your wanted level will reset back to anonymous.\
+Otherwise, if you are dead for any reason at all, your wanted level will reset back to 0.
 ```
 Note:
 - Ambush may only occur when the player is in combat.
@@ -100,10 +85,26 @@ Note:
 ```
 </details>
 
+## Clans and Groups and XP sharing
+Killing with other vampires can share XP and wanted heat levels within the group.
+
+A vampire is considered in your group if they are in your clan or if you use the `group` commands to create a group with
+them. A group will only share XP if the members are close enough to each other, governed by the `Ally Max Distance` configuration.
+
+<details>
+<summary>Experience</summary>
+Group XP is awarded based on the ratio of the average group level to the sum of the group level. It is then multiplied
+by a bonus value `( 1.2^(group size - 1) )`, up to a maximum of `1.5`.
+</details>
+
+<details>
+<summary>Heat</summary>
+Increases in heat levels are applied uniformly for every member in the group.
+</details>
+
 ## Command Permission
 Commands are configured to require a minimum level of privilege for the user to be able to use them.\
 Command privileges should be automatically created when the plugin starts (each time). Default required privilege is 100 for\
 commands marked as "isAdmin" or 0 for those not marked.
 
-Privilege levels range from 0 to 100.\
-With 0 as the default privilege for users (lowest), and 100 as the highest privilege (admin).
+Privilege levels range from 0 to 100, with 0 as the default privilege for users (lowest), and 100 as the highest privilege (admin).

--- a/Hooks/BuffHook.cs
+++ b/Hooks/BuffHook.cs
@@ -17,19 +17,6 @@ namespace XPRising.Hooks;
 [HarmonyPatch(typeof(ModifyUnitStatBuffSystem_Spawn), nameof(ModifyUnitStatBuffSystem_Spawn.OnUpdate))]
 public class ModifyUnitStatBuffSystem_Spawn_Patch
 {
-    private static void DebugBuffBuffer(EntityManager entityManager, Entity entityWithPlayerCharacter)
-    {
-        if (entityManager.TryGetBuffer<BuffBuffer>(entityWithPlayerCharacter, out var buffBuffer))
-        {
-            for (int i = 0; i < buffBuffer.Length; i++)
-            {
-                var data = buffBuffer[i];
-                DebugTool.LogPrefabGuid(data.PrefabGuid, "Item not equipped by PC:", LogSystem.Buff);
-                DebugTool.LogDebugEntity(data.Entity, $"Debug BuffBuffer[{i}]:", LogSystem.Buff);
-            }
-        }
-    }
-
     private static void Prefix(ModifyUnitStatBuffSystem_Spawn __instance)
     {
         oldStyleBuffHook(__instance);
@@ -201,7 +188,7 @@ public class DebugBuffSystem_Patch
         NativeArray<Entity> entities = __instance.__query_401358786_0.ToEntityArray(Allocator.Temp);
         foreach (var entity in entities) {
             var guid = __instance.EntityManager.GetComponentData<PrefabGUID>(entity);
-            DebugTool.LogPrefabGuid(guid, "DebugBuffSystem:");
+            DebugTool.LogPrefabGuid(guid, "BuffDebugSystem:");
 
             var combatStart = false;
             var combatEnd = false;

--- a/Hooks/BuffHook.cs
+++ b/Hooks/BuffHook.cs
@@ -24,10 +24,8 @@ public class ModifyUnitStatBuffSystem_Spawn_Patch
             for (int i = 0; i < buffBuffer.Length; i++)
             {
                 var data = buffBuffer[i];
-                Plugin.Log(Plugin.LogSystem.Buff, LogLevel.Info,
-                    $"Debug BuffBuffer[{i}]: Prefab is: {Helper.GetPrefabName(data.PrefabGuid)} ({data.PrefabGuid.GuidHash})");
-                Plugin.Log(Plugin.LogSystem.Buff, LogLevel.Info,
-                    $"Debug BuffBuffer[{i}]: Prefab is: {data.Entity} ({entityManager.Debug.GetEntityInfo(data.Entity)})");
+                DebugTool.LogPrefabGuid(data.PrefabGuid, "Item not equipped by PC:", LogSystem.Buff);
+                DebugTool.LogDebugEntity(data.Entity, $"Debug BuffBuffer[{i}]:", LogSystem.Buff);
             }
         }
     }
@@ -100,7 +98,7 @@ public class ModifyUnitStatBuffSystem_Spawn_Patch
         foreach (var entity in entities)
         {
             var prefabGuid = entityManager.GetComponentData<PrefabGUID>(entity);
-            Plugin.Log(Plugin.LogSystem.Buff, LogLevel.Info, $"Prefab is: {Helper.GetPrefabName(prefabGuid)} ({prefabGuid.GuidHash})");
+            DebugTool.LogPrefabGuid(prefabGuid, "", LogSystem.Buff);
             if (prefabGuid.GuidHash == Helper.ForbiddenBuffGuid)
             {
                 Plugin.Log(Plugin.LogSystem.Buff, LogLevel.Info, "Forbidden buff found with GUID of " + prefabGuid.GuidHash);
@@ -130,8 +128,7 @@ public class ModifyUnitStatBuffSystem_Spawn_Patch
                     !__instance.EntityManager.TryGetComponentData<User>(playerCharacter.UserEntity, out var user))
                 {
                     // Item equipped on a non-pc entity.
-                    Plugin.Log(Plugin.LogSystem.Buff, LogLevel.Info,
-                        $"Item not equipped by PC: {Helper.GetPrefabName(prefabGuid)} ({prefabGuid.GuidHash})");
+                    DebugTool.LogPrefabGuid(prefabGuid, "Item not equipped by PC:", LogSystem.Buff);
                     continue;
                 }
 
@@ -160,10 +157,10 @@ public class ModifyUnitStatBuffSystem_Destroy_Patch
                     !__instance.EntityManager.TryGetComponentData<User>(playerCharacter.UserEntity, out var user))
                 {
                     // Item equipped on a non-pc entity.
-                    Plugin.Log(Plugin.LogSystem.Buff, LogLevel.Info, $"Item not equipped by PC: {Helper.GetPrefabName(prefabGuid)} ({prefabGuid.GuidHash})");
+                    DebugTool.LogPrefabGuid(prefabGuid, "Item not equipped by PC:", LogSystem.Buff);
                     continue;
                 }
-                Plugin.Log(Plugin.LogSystem.Buff, LogLevel.Info, $"Post: Prefab is: {Helper.GetPrefabName(prefabGuid)} ({prefabGuid.GuidHash})");
+                DebugTool.LogPrefabGuid(prefabGuid, "Post:", LogSystem.Buff);
                 ExperienceSystem.SetLevel(owner, playerCharacter.UserEntity, user.PlatformId);
             }
             
@@ -173,11 +170,7 @@ public class ModifyUnitStatBuffSystem_Destroy_Patch
                 return;
             }
             
-            for (int i = 0; i < buffer.Length; i++)
-            {
-                var data = buffer[i];
-                Plugin.Log(Plugin.LogSystem.Buff, LogLevel.Info, $"Post: B[{i}]: {data.StatType} {data.Value} {data.ModificationType} {data.Id.Id} {data.Priority} {data.ValueByStacks} {data.IncreaseByStacks}");
-            }
+            DebugTool.LogStatsBuffer(buffer, "Post:", LogSystem.Buff);
         }
     }
 }
@@ -208,6 +201,7 @@ public class DebugBuffSystem_Patch
         NativeArray<Entity> entities = __instance.__query_401358786_0.ToEntityArray(Allocator.Temp);
         foreach (var entity in entities) {
             var guid = __instance.EntityManager.GetComponentData<PrefabGUID>(entity);
+            DebugTool.LogPrefabGuid(guid, "DebugBuffSystem:");
 
             var combatStart = false;
             var combatEnd = false;

--- a/Hooks/DeathHook.cs
+++ b/Hooks/DeathHook.cs
@@ -16,7 +16,7 @@ public class DeathEventListenerSystem_Patch {
     public static void Postfix(DeathEventListenerSystem __instance) {
         NativeArray<DeathEvent> deathEvents = __instance._DeathEventQuery.ToComponentDataArray<DeathEvent>(Allocator.Temp);
         foreach (DeathEvent ev in deathEvents) {
-            Plugin.Log(Plugin.LogSystem.Death, LogLevel.Info, () => $"Death Event occured for: {ev.Died} - {Helper.GetPrefabName(ev.Died)}");
+            DebugTool.LogEntity(ev.Died, "Death Event occured for:", LogSystem.Death);
 
             //-- Player Creature Kill Tracking
             var killer = ev.Killer;
@@ -24,40 +24,40 @@ public class DeathEventListenerSystem_Patch {
             //-- Check if victim is a minion
             var ignoreAsKill = false;
             if (__instance.EntityManager.HasComponent<Minion>(ev.Died)) {
-                Plugin.Log(Plugin.LogSystem.Death, LogLevel.Info, "Minion killed, ignoring as kill");
+                Plugin.Log(LogSystem.Death, LogLevel.Info, "Minion killed, ignoring as kill");
                 ignoreAsKill = true;
             }
             
             //-- Check victim has a level
             if (!__instance.EntityManager.HasComponent<UnitLevel>(ev.Died)) {
-                Plugin.Log(Plugin.LogSystem.Death, LogLevel.Info, "Has no level, ignoring as kill");
+                Plugin.Log(LogSystem.Death, LogLevel.Info, "Has no level, ignoring as kill");
                 ignoreAsKill = true;
             }
 
             if (!__instance.EntityManager.HasComponent<Movement>(ev.Died))
             {
-                Plugin.Log(Plugin.LogSystem.Death, LogLevel.Info, "Entity doesn't move, ignoring as kill");
+                Plugin.Log(LogSystem.Death, LogLevel.Info, "Entity doesn't move, ignoring as kill");
                 ignoreAsKill = true;
             }
 
             // If the entity killing is a minion, switch the killer to the owner of the minion.
             if (__instance.EntityManager.HasComponent<Minion>(killer))
             {
-                Plugin.Log(Plugin.LogSystem.Death, LogLevel.Info, $"Minion killed entity. Getting owner...");
+                Plugin.Log(LogSystem.Death, LogLevel.Info, $"Minion killed entity. Getting owner...");
                 if (__instance.EntityManager.TryGetComponentData<EntityOwner>(killer, out var entityOwner))
                 {
                     killer = entityOwner.Owner;
-                    Plugin.Log(Plugin.LogSystem.Death, LogLevel.Info, $"Owner found, switching killer to owner.");
+                    Plugin.Log(LogSystem.Death, LogLevel.Info, $"Owner found, switching killer to owner.");
                 }
             }
-            Plugin.Log(Plugin.LogSystem.Death, LogLevel.Info, () => $"[{ev.Source},{ev.Killer},{ev.Died}] => [{Helper.GetPrefabName(ev.Source)},{Helper.GetPrefabName(ev.Killer)},{Helper.GetPrefabName(ev.Died)}]");
+            Plugin.Log(LogSystem.Death, LogLevel.Info, () => $"[{ev.Source},{ev.Killer},{ev.Died}] => [{DebugTool.GetPrefabName(ev.Source)},{DebugTool.GetPrefabName(ev.Killer)},{DebugTool.GetPrefabName(ev.Died)}]");
             
             // If the killer is the victim, then we can skip trying to add xp, heat, mastery, bloodline.
             if (!ignoreAsKill && !killer.Equals(ev.Died))
             {
                 if (__instance.EntityManager.HasComponent<PlayerCharacter>(killer))
                 {
-                    Plugin.Log(Plugin.LogSystem.Death, LogLevel.Info,
+                    Plugin.Log(LogSystem.Death, LogLevel.Info,
                         $"Killer ({killer}) is a player, running xp and heat and the like");
 
                     if (Plugin.ExperienceSystemActive || Plugin.WantedSystemActive)
@@ -69,7 +69,7 @@ public class DeathEventListenerSystem_Patch {
                         var triggerLocation = Plugin.Server.EntityManager.GetComponentData<LocalToWorld>(ev.Died);
                         var closeAllies = Alliance.GetClosePlayers(
                             triggerLocation.Position, killer, ExperienceSystem.GroupMaxDistance, true, useGroup,
-                            Plugin.LogSystem.Death);
+                            LogSystem.Death);
 
                         // If you get experience for the kill, you get heat for the kill
                         if (Plugin.ExperienceSystemActive) ExperienceSystem.ExpMonitor(closeAllies, ev.Died, isVBlood);
@@ -92,7 +92,7 @@ public class DeathEventListenerSystem_Patch {
             // Player death
             if (__instance.EntityManager.TryGetComponentData<RespawnCharacter>(ev.Died, out var respawnData))
             {
-                Plugin.Log(Plugin.LogSystem.Death, LogLevel.Info, $"the deceased ({ev.Died}) is a player, running xp loss and heat dumping");
+                Plugin.Log(LogSystem.Death, LogLevel.Info, $"the deceased ({ev.Died}) is a player, running xp loss and heat dumping");
                 if (Plugin.WantedSystemActive) WantedSystem.PlayerDied(ev.Died);
                 if (Plugin.ExperienceSystemActive) ExperienceSystem.DeathXpLoss(ev.Died, respawnData.KillerEntity._Entity);
             }

--- a/Hooks/SaveSystemHook.cs
+++ b/Hooks/SaveSystemHook.cs
@@ -10,7 +10,6 @@ namespace XPRising.Hooks
     {
         public static void Postfix()
         {
-            Plugin.Log(Plugin.LogSystem.Core, LogLevel.Info, "Autosaving...", true);
             AutoSaveSystem.SaveDatabase(false, false);
         }
     }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -154,9 +154,16 @@ namespace XPRising
             
             //-- Initialize System
             // Pre-initialise some constants
-            // Helper.GetServerGameSettings(out _);
             Helper.GetServerGameManager(out _);
-            // Helper.GetUserActivityGridSystem(out _);
+            
+            // Ensure that there is a consistent starting level to the server settings
+            if (ExperienceSystemActive)
+            {
+                var serverSettings = Plugin.Server.GetExistingSystemManaged<ServerGameSettingsSystem>();
+                var startingXpLevel = serverSettings.Settings.StartingProgressionLevel;
+                ExperienceSystem.StartingExp = ExperienceSystem.ConvertLevelToXp(startingXpLevel) + 1; // Add 1 to make it show start of this level, rather than end of last.
+                Plugin.Log(LogSystem.Xp, LogLevel.Info, $"Starting XP level set to {startingXpLevel} to match server settings", true);
+            }
             
             DebugLoggingConfig.Initialize();
             if (BloodlineSystemActive) BloodlineConfig.Initialize();

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using BepInEx;
 using VampireCommandFramework;
 using BepInEx.Logging;
@@ -208,13 +209,30 @@ namespace XPRising
         public new static void Log(LogSystem system, LogLevel logLevel, string message, bool forceLog = false)
         {
             var isLogging = forceLog || DebugLoggingConfig.IsLogging(system);
-            if (isLogging) _logger.Log(logLevel, $"{DateTime.Now.ToString("u")}: [{Enum.GetName(system)}] {message}");
+            if (isLogging) _logger.Log(logLevel, ToLogMessage(system, message));
         }
         
         // Log overload to allow potentially more computationally expensive logs to be hidden when not being logged
         public new static void Log(LogSystem system, LogLevel logLevel, Func<string> messageGenerator, bool forceLog = false)
         {
-            Log(system, logLevel, messageGenerator(), forceLog);
+            var isLogging = forceLog || DebugLoggingConfig.IsLogging(system);
+            if (isLogging) _logger.Log(logLevel, ToLogMessage(system, messageGenerator()));
+        }
+        
+        // Log overload to allow enumerations to only be iterated over if logging
+        public new static void Log(LogSystem system, LogLevel logLevel, IEnumerable<string> messages, bool forceLog = false)
+        {
+            var isLogging = forceLog || DebugLoggingConfig.IsLogging(system);
+            if (!isLogging) return;
+            foreach (var message in messages)
+            {
+                _logger.Log(logLevel, ToLogMessage(system, message));
+            }
+        }
+
+        private static string ToLogMessage(LogSystem logSystem, string message)
+        {
+            return $"{DateTime.Now:u}: [{Enum.GetName(logSystem)}] {message}";
         }
     }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -92,9 +92,16 @@ namespace XPRising
             {
                 WaypointCommands.WaypointLimit = Config.Bind("Config", "Waypoint Limit", 2, "Set a waypoint limit for per non-admin user.").Value;
             }
+
+            Config.SaveOnConfigSet = true;
+            var autoSaveFrequency = Config.Bind("Auto-save", "Frequency", 10, "Request the frequency for auto-saving the database. Value is in minutes. Minimum is 2.");
+            var backupSaveFrequency = Config.Bind("Auto-save", "Backup", 0, "Enable and request the frequency for saving to the backup folder. Value is in minutes. 0 to disable.");
+            if (autoSaveFrequency.Value < 2) autoSaveFrequency.Value = 10;
+            if (backupSaveFrequency.Value < 0) backupSaveFrequency.Value = 0;
             
-            AutoSaveSystem.AutoSaveFrequency = Config.Bind("Auto-save", "Frequency", 5, "Enable and set the frequency for auto-saving the database. 0 is disabled, 1 is every time the server saves, 2 is every second time, etc.").Value;
-            AutoSaveSystem.BackupFrequency = Config.Bind("Auto-save", "Backup", 0, "Enable and set the frequency for saving to the backup folder. The backup save will run every X saves. 0 to disable.").Value;
+            // Save frequency is set to a TimeSpan of 30s less than specified, so that the auto-save won't miss being triggered by seconds.
+            AutoSaveSystem.AutoSaveFrequency = TimeSpan.FromMinutes(autoSaveFrequency.Value * 60 - 30);
+            AutoSaveSystem.BackupFrequency = backupSaveFrequency.Value < 1 ? TimeSpan.Zero : TimeSpan.FromMinutes(backupSaveFrequency.Value * 60 - 30);
         }
 
         public override void Load()

--- a/README.md
+++ b/README.md
@@ -1,46 +1,44 @@
 # XPRising
 
-> This is a revitalisation of RPGMods. It has similar core ideas, with some reduced config complexity, looking to upgrade into the future.
+This is a revitalisation of RPGMods. It has similar core ideas, with some reduced config complexity, looking to upgrade into the future.
 
-# XPRising Update for 1.0
+## XPRising update for V Rising 1.0
 
-> Initial release for 1.0 current in testing. Check the releases page for recent (pre-release) versions.
+Initial release for 1.0 current in testing. Check the releases page for recent (pre-release) versions.
 
-# XPRising Requirements
+### XPRising Requirements
 
 - [BepInExPack V Rising](https://v-rising.thunderstore.io/package/BepInEx/BepInExPack_V_Rising/) (Server)
 - [BloodStone](https://v-rising.thunderstore.io/package/deca/Bloodstone/) (Server)
 - [VampireCommandFramework](https://v-rising.thunderstore.io/package/deca/VampireCommandFramework/) (Server)
 
-# Further documentation
+## Documentation
 
-A full list of commands (when all the systems are configured to be on) can be found [here](Command.md)
+- [ChangeLog](CHANGELOG.md)
+- [Command list](Command.md): A full list of commands (when all the systems are configured to be on) can be found here.
+- [System documentation](Documentation.md): Each of the systems has some further documentation on this link. It is worth noting that
+while both the weapon and bloodline mastery systems are intended to provide bonus stats, this is a work in progress and they don't actually provide anything yet.
 
-Documentation for the individual systems can be found [here](Documentation.md). It is worth noting that while both the weapon and bloodline mastery systems\
-are intended to provide bonus stats, this is a work in progress and they don't actually provide anything yet.
+## Contributors
 
+- [Kaltharos](https://github.com/Kaltharos)
+- [Dresmyr](https://github.com/Darkon47)
+- [Trodi](https://github.com/oscarpedrero)
+- [deca](https://github.com/decaprime)
+- [aontas](https://github.com/aontas)
+- Jason Williams (`SALTYFLEA#3772`)
 
-# Credits
+#### Other thanks
 
-The RPG mod was initially developed by [Kaltharos](https://github.com/Kaltharos).
+- `Dimentox#1154` (Discord)
+- `Nopey#1337` (Discord)
+- `syllabicat#0692` (Discord)
+- `errox#7604` (Discord)
+- Jason Williams (`SALTYFLEA#3772`)
+- [adainrivers](https://github.com/adainrivers)
 
-Other contributors:
-`Dimentox#1154` (Discord), `Nopey#1337` (Discord), `syllabicat#0692` (Discord), `errox#7604` (Discord), Jason Williams (`SALTYFLEA#3772`), [Trodi](https://github.com/oscarpedrero), [Dresmyr](https://github.com/Darkon47), [aontas](https://github.com/aontas)
+#### [V Rising Mod Community](https://discord.gg/vrisingmods) - the premier community for V Rising mods
 
-Some code snippets have been lifted from The Random Encounters mod, developed by [adainrivers](https://github.com/adainrivers/randomencounters).
-
-[V Rising Mod Community](https://discord.gg/vrisingmods) - the premier community for V Rising mods.
-
-# By the community, for the community
+## By the community, for the community
 
 > It was crucial for us to keep the code open source to ensure excellent support and provide other mod developers the opportunity to develop plugins for XPRising at any time. This project is free and open to everyone, created by the community for the community, and everyone is a part of the development!
-
-# Patch notes / Changelog
-
-- 0.1.0 Initial update for VRising 1.0
-- 0.1.1
-  - Fix crash when trying to determine nearby allies (for group xp/heat)
-  - Added a new command to temporarily bypass the lvl 20 requirement for the "Getting ready for the Hunt" journal
-  - Fixed bloodline mastery logging to only log when you have it enabled
-  - Changed the mod icon
-  - Linked the other documentation files to README.md

--- a/Systems/RandomEncountersSystem.cs
+++ b/Systems/RandomEncountersSystem.cs
@@ -61,7 +61,7 @@ namespace XPRising.Systems
             var userLevel = ExperienceSystem.GetLevel(user.SteamID);
             var npc = DataFactory.GetRandomNpc(userLevel);
             var npcPrefab = new PrefabGUID((int)npc.type);
-            Plugin.Log(LoggingSystem, LogLevel.Message, $"Attempting to start a new encounter for {user.CharacterName} with {Helper.GetPrefabName(npcPrefab)}");
+            Plugin.Log(LoggingSystem, LogLevel.Message, $"Attempting to start a new encounter for {user.CharacterName} with {DebugTool.GetPrefabName(npcPrefab)}");
             var minSpawnDistance = RandomEncountersConfig.MinSpawnDistance.Value;
             var maxSpawnDistance = RandomEncountersConfig.MaxSpawnDistance.Value;
             try
@@ -110,11 +110,11 @@ namespace XPRising.Systems
                 RewardsMap[steamID] = new ConcurrentDictionary<int, ItemDataModel>();
             }
 
-            var npcName = Helper.GetPrefabName(prefabGuid);
+            var npcName = DebugTool.GetPrefabName(prefabGuid);
 
             var message = string.Format(MessageTemplate, npcName, Lifetime);
 
-            Cache.SteamPlayerCache.TryGetValue(steamID, out var user);
+            var user = Cache.SteamPlayerCache[steamID];
 
             Output.SendLore(user.UserEntity, message);
             Plugin.Log(LoggingSystem, LogLevel.Info, $"Encounters started: {user.CharacterName} vs. {npcName}");

--- a/Systems/WeaponMasterySystem.cs
+++ b/Systems/WeaponMasterySystem.cs
@@ -130,7 +130,7 @@ namespace XPRising.Systems
                 
                 if (updateSpellMastery)
                 {
-                    var currentSpellMastery = wd.GetValueOrDefault(MasteryType.Spell).Mastery;
+                    var currentSpellMastery = wd[MasteryType.Spell].Mastery;
                     Output.SendLore(userEntity, $"<color={Output.DarkYellow}>Weapon mastery has increased by {changeInSpellMastery:F3}% [ Spell: {currentSpellMastery:F2}% ]</color>");
                 }
             }
@@ -140,8 +140,8 @@ namespace XPRising.Systems
         {
             var steamID = _em.GetComponentData<User>(user).PlatformId;
 
-            Cache.player_last_combat.TryGetValue(steamID, out var lastCombat);
-            Cache.player_combat_ticks.TryGetValue(steamID, out var combatTicks);
+            var lastCombat = Cache.player_last_combat[steamID];
+            var combatTicks = Cache.player_combat_ticks[steamID];
             var elapsedTime = DateTime.Now - lastCombat;
             if (elapsedTime.TotalSeconds >= 10) combatTicks = 0;
             if (elapsedTime.TotalSeconds * 0.2 < 1) return;
@@ -154,7 +154,7 @@ namespace XPRising.Systems
             var wd = Database.PlayerWeaponmastery[steamID];
             
             var weaponGrowth = wd[masteryType].Growth;
-            var spellGrowth = wd.GetValueOrDefault(MasteryType.Spell).Growth;
+            var spellGrowth = wd[MasteryType.Spell].Growth;
 
             var changeInMastery = (MasteryCombatTick * weaponGrowth)/1000.0;
             var changeInSpellMastery = (MasteryCombatTick * spellGrowth)/1000.0;

--- a/Utils/Database.cs
+++ b/Utils/Database.cs
@@ -108,6 +108,6 @@ namespace XPRising.Utils
         public static LazyDictionary<BloodlineSystem.BloodType, List<StatConfig>> BloodlineStatConfig = new();
         
         //-- -- Alliance System
-        public static LazyDictionary<Entity, AlliancePlayerPreferences> AlliancePlayerPrefs = new();
+        public static LazyDictionary<ulong, AlliancePlayerPreferences> AlliancePlayerPrefs = new();
     }
 }

--- a/Utils/DebugTool.cs
+++ b/Utils/DebugTool.cs
@@ -1,0 +1,84 @@
+﻿using BepInEx.Logging;
+using System.Collections.Generic;
+using ProjectM;
+using Stunlock.Core;
+using Unity.Entities;
+
+namespace XPRising.Utils;
+
+public class DebugTool
+{
+    private static string MaybeAddSpace(string input)
+    {
+        return input.Length > 0 ? input.TrimEnd() + " " : input;
+    }
+    
+    public static PrefabGUID GetAndLogPrefabGuid(Entity entity, string logPrefix = "", Plugin.LogSystem logSystem = Plugin.LogSystem.Core)
+    {
+        var guid = Helper.GetPrefabGUID(entity);
+        LogPrefabGuid(guid, logPrefix, logSystem);
+        return guid;
+    }
+    
+    public static void LogPrefabGuid(PrefabGUID guid, string logPrefix = "", Plugin.LogSystem logSystem = Plugin.LogSystem.Core)
+    {
+        Plugin.Log(logSystem, LogLevel.Info, () => $"{MaybeAddSpace(logPrefix)}Prefab: {GetPrefabName(guid)} ({guid.GuidHash})");
+    }
+
+    public static void LogEntity(Entity entity, string logPrefix = "",
+        Plugin.LogSystem logSystem = Plugin.LogSystem.Core)
+    {
+        Plugin.Log(logSystem, LogLevel.Info, () => $"{MaybeAddSpace(logPrefix)}{entity} - {GetPrefabName(entity)}");
+    }
+
+    public static void LogDebugEntity(
+        Entity entity,
+        string logPrefix = "",
+        Plugin.LogSystem logSystem = Plugin.LogSystem.Core)
+    {
+        Plugin.Log(logSystem, LogLevel.Info,
+            () => $"{MaybeAddSpace(logPrefix)}Entity: {entity} ({Plugin.Server.EntityManager.Debug.GetEntityInfo(entity)})");
+    }
+
+    private static IEnumerable<string> StatsBufferToEnumerable(DynamicBuffer<ModifyUnitStatBuff_DOTS> buffer, string logPrefix = "")
+    {
+        for (var i = 0; i < buffer.Length; i++)
+        {
+            var data = buffer[i];
+            yield return $"{MaybeAddSpace(logPrefix)}B[{i}]: {data.StatType} {data.Value} {data.ModificationType} {data.Id.Id} {data.Priority} {data.ValueByStacks} {data.IncreaseByStacks}";
+        }
+    }
+    
+    public static void LogStatsBuffer(
+        DynamicBuffer<ModifyUnitStatBuff_DOTS> buffer,
+        string logPrefix = "",
+        Plugin.LogSystem logSystem = Plugin.LogSystem.Core)
+    {
+        Plugin.Log(logSystem, LogLevel.Info, StatsBufferToEnumerable(buffer, logPrefix));
+        
+    }
+    
+    public static string GetPrefabName(PrefabGUID hashCode)
+    {
+        var s = Plugin.Server.GetExistingSystemManaged<PrefabCollectionSystem>();
+        string name = "Nonexistent";
+        if (hashCode.GuidHash == 0)
+        {
+            return name;
+        }
+        try
+        {
+            name = s.PrefabGuidToNameDictionary[hashCode];
+        }
+        catch
+        {
+            name = "NoPrefabName";
+        }
+        return name;
+    }
+
+    public static string GetPrefabName(Entity entity)
+    {
+        return GetPrefabName(Helper.GetPrefabGUID(entity));
+    }
+}

--- a/Utils/DebugTool.cs
+++ b/Utils/DebugTool.cs
@@ -1,4 +1,5 @@
-﻿using BepInEx.Logging;
+﻿using System;
+using BepInEx.Logging;
 using System.Collections.Generic;
 using ProjectM;
 using Stunlock.Core;
@@ -6,56 +7,90 @@ using Unity.Entities;
 
 namespace XPRising.Utils;
 
-public class DebugTool
+public static class DebugTool
 {
     private static string MaybeAddSpace(string input)
     {
         return input.Length > 0 ? input.TrimEnd() + " " : input;
     }
     
-    public static PrefabGUID GetAndLogPrefabGuid(Entity entity, string logPrefix = "", Plugin.LogSystem logSystem = Plugin.LogSystem.Core)
+    public static PrefabGUID GetAndLogPrefabGuid(Entity entity, string logPrefix = "", Plugin.LogSystem logSystem = Plugin.LogSystem.Core, bool forceLog = false)
     {
         var guid = Helper.GetPrefabGUID(entity);
-        LogPrefabGuid(guid, logPrefix, logSystem);
+        LogPrefabGuid(guid, logPrefix, logSystem, forceLog);
         return guid;
     }
     
-    public static void LogPrefabGuid(PrefabGUID guid, string logPrefix = "", Plugin.LogSystem logSystem = Plugin.LogSystem.Core)
+    public static void LogPrefabGuid(PrefabGUID guid, string logPrefix = "", Plugin.LogSystem logSystem = Plugin.LogSystem.Core, bool forceLog = false)
     {
-        Plugin.Log(logSystem, LogLevel.Info, () => $"{MaybeAddSpace(logPrefix)}Prefab: {GetPrefabName(guid)} ({guid.GuidHash})");
+        Plugin.Log(logSystem, LogLevel.Info, () => $"{MaybeAddSpace(logPrefix)}Prefab: {GetPrefabName(guid)} ({guid.GuidHash})", forceLog);
     }
 
-    public static void LogEntity(Entity entity, string logPrefix = "",
-        Plugin.LogSystem logSystem = Plugin.LogSystem.Core)
+    public static void LogEntity(
+        Entity entity,
+        string logPrefix = "",
+        Plugin.LogSystem logSystem = Plugin.LogSystem.Core,
+        bool forceLog = false)
     {
-        Plugin.Log(logSystem, LogLevel.Info, () => $"{MaybeAddSpace(logPrefix)}{entity} - {GetPrefabName(entity)}");
+        Plugin.Log(logSystem, LogLevel.Info, () => $"{MaybeAddSpace(logPrefix)}{entity} - {GetPrefabName(entity)}", forceLog);
     }
 
     public static void LogDebugEntity(
         Entity entity,
         string logPrefix = "",
-        Plugin.LogSystem logSystem = Plugin.LogSystem.Core)
+        Plugin.LogSystem logSystem = Plugin.LogSystem.Core,
+        bool forceLog = false)
     {
         Plugin.Log(logSystem, LogLevel.Info,
-            () => $"{MaybeAddSpace(logPrefix)}Entity: {entity} ({Plugin.Server.EntityManager.Debug.GetEntityInfo(entity)})");
+            () => $"{MaybeAddSpace(logPrefix)}Entity: {entity} ({Plugin.Server.EntityManager.Debug.GetEntityInfo(entity)})", forceLog);
     }
 
-    private static IEnumerable<string> StatsBufferToEnumerable(DynamicBuffer<ModifyUnitStatBuff_DOTS> buffer, string logPrefix = "")
+    public static void LogFullEntityDebugInfo(Entity entity, bool forceLog = false)
+    {
+        Plugin.Log(Plugin.LogSystem.Core, LogLevel.Info, () =>
+        {
+            var sb = new Il2CppSystem.Text.StringBuilder();
+            ProjectM.EntityDebuggingUtility.DumpEntity(Plugin.Server, entity, true, sb);
+            return $"Debug entity: {sb.ToString()}";
+        }, forceLog);
+    }
+
+    private static IEnumerable<string> StatsBufferToEnumerable<T>(DynamicBuffer<T> buffer, Func<T, string> valueToString, string logPrefix = "")
     {
         for (var i = 0; i < buffer.Length; i++)
         {
             var data = buffer[i];
-            yield return $"{MaybeAddSpace(logPrefix)}B[{i}]: {data.StatType} {data.Value} {data.ModificationType} {data.Id.Id} {data.Priority} {data.ValueByStacks} {data.IncreaseByStacks}";
+            yield return $"{MaybeAddSpace(logPrefix)}B[{i}]: {valueToString(data)}";
         }
     }
     
     public static void LogStatsBuffer(
         DynamicBuffer<ModifyUnitStatBuff_DOTS> buffer,
         string logPrefix = "",
-        Plugin.LogSystem logSystem = Plugin.LogSystem.Core)
+        Plugin.LogSystem logSystem = Plugin.LogSystem.Core,
+        bool forceLog = false)
     {
-        Plugin.Log(logSystem, LogLevel.Info, StatsBufferToEnumerable(buffer, logPrefix));
+        Func<ModifyUnitStatBuff_DOTS, string> printStats = (data) =>
+            $"{data.StatType} {data.Value} {data.ModificationType} {data.Id.Id} {data.Priority} {data.ValueByStacks} {data.IncreaseByStacks}"; 
+        Plugin.Log(logSystem, LogLevel.Info, StatsBufferToEnumerable(buffer, printStats, logPrefix), forceLog);
+    }
+
+    public static void LogBuffBuffer(
+        DynamicBuffer<BuffBuffer> buffer,
+        string logPrefix = "",
+        Plugin.LogSystem logSystem = Plugin.LogSystem.Core,
+        bool forceLog = false)
+    {
+        // for (int i = 0; i < buffer.Length; i++)
+        // {
+        //     var data = buffer[i];
+        //     DebugTool.LogPrefabGuid(data.PrefabGuid, "Item not equipped by PC:", logSystem);
+        //     DebugTool.LogDebugEntity(data.Entity, $"Debug BuffBuffer[{i}]:", logSystem);
+        // }
         
+        Func<BuffBuffer, string> printStats = (data) =>
+            $"Prefab: {GetPrefabName(data.PrefabGuid)}\nDebug BuffBuffer:{Plugin.Server.EntityManager.Debug.GetEntityInfo(data.Entity)}"; 
+        Plugin.Log(logSystem, LogLevel.Info, StatsBufferToEnumerable(buffer, printStats, logPrefix), forceLog);
     }
     
     public static string GetPrefabName(PrefabGUID hashCode)

--- a/Utils/Helper.cs
+++ b/Utils/Helper.cs
@@ -357,30 +357,6 @@ namespace XPRising.Utils
 
             return prefabGuid;
         }
-
-        public static string GetPrefabName(PrefabGUID hashCode)
-        {
-            var s = Plugin.Server.GetExistingSystemManaged<PrefabCollectionSystem>();
-            string name = "Nonexistent";
-            if (hashCode.GuidHash == 0)
-            {
-                return name;
-            }
-            try
-            {
-                name = s.PrefabGuidToNameDictionary[hashCode];
-            }
-            catch
-            {
-                name = "NoPrefabName";
-            }
-            return name;
-        }
-
-        public static string GetPrefabName(Entity entity)
-        {
-            return GetPrefabName(GetPrefabGUID(entity));
-        }
         
         public static Prefabs.Faction ConvertGuidToFaction(PrefabGUID guid) {
             if (Enum.IsDefined(typeof(Prefabs.Faction), guid.GetHashCode())) return (Prefabs.Faction)guid.GetHashCode();

--- a/Utils/Helper.cs
+++ b/Utils/Helper.cs
@@ -473,13 +473,6 @@ namespace XPRising.Utils
             return false;
         }
 
-        public static void LogEntityDebugInfo(Entity entity)
-        {
-            var sb = new Il2CppSystem.Text.StringBuilder();
-            ProjectM.EntityDebuggingUtility.DumpEntity(Plugin.Server, entity, true, sb);
-            Plugin.Log(Plugin.LogSystem.Core, LogLevel.Info, $"Debug entity: {sb.ToString()}", true);
-        }
-
         // For stats that reduce as a multiplier of 1 - their value, so that a value of 0.5 halves the stat, and 0.75 quarters it.
         // I do this so that we can compute linear increases to a formula of X/(X+Y) where Y is the amount for +100% effectivness and X is the stat value
         public static HashSet<UnitStatType> inverseMultiplierStats = new()

--- a/Utils/Output.cs
+++ b/Utils/Output.cs
@@ -5,7 +5,7 @@ namespace XPRising.Utils
 {
     public static class Output
     {
-        public const string White = "#ffffff";
+        public const string White = "white";
         public const string Green = "#75ff33";
         public const string Gray = "#8d8d8d";
         public const string DarkYellow = "#ffb700";

--- a/XPRising.csproj
+++ b/XPRising.csproj
@@ -11,6 +11,10 @@
     <AssemblyVersion>0.1.0</AssemblyVersion>
     <FileVersion>0.1.0</FileVersion>
     </PropertyGroup>
+    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+      <Optimize>true</Optimize>
+      <DebugSymbols>false</DebugSymbols>
+    </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.688" IncludeAssets="compile"/>

--- a/XPRising.csproj
+++ b/XPRising.csproj
@@ -8,8 +8,6 @@
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
         <NoWarn>$(NoWarn);NU5104</NoWarn>
         <PackageId>XPRising</PackageId>
-    <AssemblyVersion>0.1.0</AssemblyVersion>
-    <FileVersion>0.1.0</FileVersion>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
       <Optimize>true</Optimize>

--- a/XPRising.sln
+++ b/XPRising.sln
@@ -11,10 +11,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{D63120F7-44BA-44E3-B607-945646D5A96E}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{D63120F7-44BA-44E3-B607-945646D5A96E}.Debug|Any CPU.Build.0 = Release|Any CPU
 		{D63120F7-44BA-44E3-B607-945646D5A96E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D63120F7-44BA-44E3-B607-945646D5A96E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D63120F7-44BA-44E3-B607-945646D5A96E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D63120F7-44BA-44E3-B607-945646D5A96E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Added

- Added support to load starting XP for player characters directly from the server configuration options.
Server admins can now set lowest level via this setting.
- Improved auto-save config to aid admin configuration 

### Fixed

- `group add` command can now be successfully run
- Fixed bug with attempting to read Weapon mastery data from internal database
- Bloodine mastery logging now correctly only happens if the player has enabled it
- Fixed auto-saving to correctly only log that it is saving when it is saving
- Stopped start-up logs from complaining about debug functions not provided to players
- Fixed white text colouring in messages to players
- Fixed saving alliance/custom group user preferences

### Changed

- Added this ChangeLog
- Updated documentation for clarity