### PR TITLE
0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.1.6] - 2024-05-22
+
+### Added
+
+- `.playerinfo` now also displays the buffs of the given player
+
+### Fixed
+
+- Fix brute blood buff > 30% strength from messing with player levels. It will still add a single level to maintain the bloodline power, but won't change the level more than that.
+- DB initialisation/loading will now correctly initialise the data for hardcoded defaults
+
 ## [0.1.5] - 2024-05-21
 
 ### Fixed

--- a/Commands/BloodlineCommands.cs
+++ b/Commands/BloodlineCommands.cs
@@ -26,9 +26,6 @@ namespace XPRising.Commands
                 {
                     var val = Helper.CalcBuffValue(masteryData.Mastery, masteryData.Effectiveness, statConfig.rate, statConfig.type);
                     // If the value was inverted for the buff calculation, un-invert it here.
-                    if (Helper.inverseMultipersDisplayReduction && Helper.inverseMultiplierStats.Contains(statConfig.type)) {
-                        val = 1 - val;
-                    }
                     if (Helper.percentageStats.Contains(statConfig.type) && Helper.humanReadablePercentageStats) {
                         return $"{Helper.CamelCaseToSpaces(statConfig.type)} <color={Output.Green}>{val/100:F3}%</color>";
                     }

--- a/Commands/MasteryCommands.cs
+++ b/Commands/MasteryCommands.cs
@@ -75,12 +75,6 @@ namespace XPRising.Commands {
             {
                 var val = Helper.CalcBuffValue(mastery, effectiveness, config.rate, config.type);
                 
-                // If the value was inverted for the buff calculation, un-invert it here.
-                if (Helper.inverseMultipersDisplayReduction && Helper.inverseMultiplierStats.Contains(config.type))
-                {
-                    val = 1 - val;
-                }
-                
                 if (Helper.percentageStats.Contains(config.type) && Helper.humanReadablePercentageStats) {
                     return $"{Helper.CamelCaseToSpaces(config.type)} <color={Output.Green}>{val/100:F3}%</color>";
                 }

--- a/Commands/PlayerInfoCommands.cs
+++ b/Commands/PlayerInfoCommands.cs
@@ -85,8 +85,23 @@ namespace XPRising.Commands
                 var currentXp = ExperienceSystem.GetXp(playerData.SteamID);
                 var currentLevel = ExperienceSystem.ConvertXpToLevel(currentXp);
                 ExperienceSystem.GetLevelAndProgress(currentXp, out _, out var xpEarned, out var xpNeeded);
-                ctx.Reply($"-- <color={Output.White}>Experience --");
+                ctx.Reply($"-- <color={Output.White}>Experience</color> --");
                 ctx.Reply($"Level: <color={Output.White}>{currentLevel.ToString()}</color> [<color={Output.White}>{xpEarned.ToString()}</color>/<color={Output.White}>{xpNeeded.ToString()}</color>]");
+            }
+            
+            // Get buffs for user
+            var statusBonus = Helper.GetAllStatBonuses(playerData.SteamID, playerData.CharEntity);
+            ctx.Reply($"-- <color={Output.White}>Stat buffs</color> --");
+            if (statusBonus.Count > 0)
+            {
+                foreach (var pair in statusBonus)
+                {
+                    ctx.Reply($"{Helper.CamelCaseToSpaces(pair.Key)}: {pair.Value:F2}");
+                }
+            }
+            else
+            {
+                ctx.Reply("None");
             }
         }
     }

--- a/Configuration/MasteryConfig.cs
+++ b/Configuration/MasteryConfig.cs
@@ -17,8 +17,6 @@ public static class MasteryConfig
         _configFile = new ConfigFile(configPath, true);
         
         // Currently, we are never updating and saving the config file in game, so just load the values.
-        WeaponMasterySystem.SpellMasteryNeedsUnarmedToUse = _configFile.Bind("Mastery", "Unarmed Only Spell Mastery Use", false, "Gain the benefits of spell mastery only when you have no weapon equipped.").Value;
-        WeaponMasterySystem.SpellMasteryNeedsUnarmedToLearn = _configFile.Bind("Mastery", "Unarmed Only Spell Mastery Learning", true, "Progress spell mastery only when you have no weapon equipped.").Value;
         WeaponMasterySystem.MasteryCombatTick = _configFile.Bind("Mastery", "Mastery Value/Combat Ticks", 5, "Configure the amount of mastery gained per combat ticks. (5 -> 0.005%)").Value;
         WeaponMasterySystem.MaxCombatTick = _configFile.Bind("Mastery", "Max Combat Ticks", 12, "Mastery will no longer increase after this many ticks is reached in combat. (1 tick = 5 seconds)").Value;
         WeaponMasterySystem.MasteryGainMultiplier = _configFile.Bind("Mastery", "Mastery Gain Multiplier", 1.0, "Multiply the gained mastery value by this amount.").Value;

--- a/Hooks/EquipmentSystemHook.cs
+++ b/Hooks/EquipmentSystemHook.cs
@@ -4,8 +4,6 @@ using Unity.Entities;
 using Unity.Collections;
 using ProjectM.Network;
 using ProjectM;
-using XPRising.Utils;
-using System;
 using BepInEx.Logging;
 using XPRising.Systems;
 using LogSystem = XPRising.Plugin.LogSystem;
@@ -17,16 +15,22 @@ public class ArmorLevelSystem_Spawn_Patch
 {
     private static void Prefix(ArmorLevelSystem_Spawn __instance)
     {
-        // Plugin.Log(LogSystem.Buff, LogLevel.Info, "Armor System Patch Entry");
-        // if (Plugin.ExperienceSystemActive)
-        // {
-        //     EntityManager entityManager = __instance.EntityManager;
-        //     NativeArray<Entity> entities = __instance.__query_663986227_0.ToEntityArray(Allocator.Temp);
-        //     foreach (var entity in entities){
-        //         Entity Owner = entityManager.GetComponentData<EntityOwner>(entity).Owner;
-        //         // TODO buff the armour based on our bloodline?
-        //     }
-        // }
+        Plugin.Log(LogSystem.Buff, LogLevel.Info, "Armor System Patch Entry");
+        if (Plugin.ExperienceSystemActive)
+        {
+            var entityManager = __instance.EntityManager;
+            var entities = __instance.__query_663986227_0.ToEntityArray(Allocator.Temp);
+            foreach (var entity in entities){
+                // Remove any armor level, as we set this manually to generate the player level.
+                // This ensures that the Effects.AB_BloodBuff_Brute_GearLevelBonus does not give us extra unintended
+                // levels. (It does allow just the brute bonus, but nothing more).
+                if (entityManager.TryGetComponentData<ArmorLevel>(entity, out var armorLevel))
+                {
+                    armorLevel.Level = 0;
+                    entityManager.SetComponentData(entity, armorLevel);
+                }
+            }
+        }
     }
     
     private static void Postfix(ArmorLevelSystem_Spawn __instance)

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -77,7 +77,6 @@ namespace XPRising
             Helper.AppliedBuff = new PrefabGUID(Helper.buffGUID);
             Helper.ForbiddenBuffGuid = Config.Bind("Core", "Forbidden Buff GUID", Helper.ForbiddenBuffGuid, "The GUID of the buff that prohibits you from getting mastery buffs\nDefault is boneguard set bonus 1. If this is the same value as Buff GUID, then none will get buffs.\nThe only reason to change this is if it clashes with another mod.").Value;
             Helper.humanReadablePercentageStats = Config.Bind("Core", "Human Readable Percentage Stats", true, "Determines if rates for percentage stats should be read as out of 100 instead of 1.").Value;
-            Helper.inverseMultipersDisplayReduction = Config.Bind("Core", "Inverse Multipliers Display Reduction", true, "Determines if inverse multiplier stats display their reduction, or the final value.").Value;
             
             _adminCommandsRequireAdmin = Config.Bind("Admin", "Admin commands require admin", true, "When set to false, commands marked as requiring admin, no longer require admin.").Value;
 

--- a/Systems/BloodlineSystem.cs
+++ b/Systems/BloodlineSystem.cs
@@ -206,16 +206,13 @@ namespace XPRising.Systems
             Database.PlayerBloodline[steamID] = bld;
         }
         
-        public static void BuffReceiver(DynamicBuffer<ModifyUnitStatBuff_DOTS> buffer, Entity owner, ulong steamID) {
+        public static void BuffReceiver(ref LazyDictionary<UnitStatType, float> statBonus, Entity owner, ulong steamID) {
             if (!_em.TryGetComponentData<Blood>(owner, out var bloodline) ||
                 !GuidToBloodType(bloodline.BloodType, false, out var bloodType))
             {
                 return;
             }
-            ApplyBloodlineBuffs(buffer, bloodType, steamID);
-        }
-        private static void ApplyBloodlineBuffs(DynamicBuffer<ModifyUnitStatBuff_DOTS> buffer, BloodType bloodType, ulong steamID)
-        {
+            
             var bld = Database.PlayerBloodline[steamID];
 
             if (InactiveMultiplier > 0)
@@ -231,7 +228,7 @@ namespace XPRising.Systems
                         // Skip if we don't have enough mastery for this bonus
                         if (mastery.Mastery < statConfig.strength) continue;
                         var value = Helper.CalcBuffValue(masteryValue, effectiveness, statConfig.rate, statConfig.type);
-                        buffer.Add(Helper.MakeBuff(statConfig.type, value));
+                        statBonus[statConfig.type] += (float)value;
                     }
                 }
             }
@@ -246,7 +243,7 @@ namespace XPRising.Systems
                     if (bloodlineMastery.Mastery < statConfig.strength) continue;
                     
                     var value = Helper.CalcBuffValue(masteryValue, effectiveness, statConfig.rate, statConfig.type);
-                    buffer.Add(Helper.MakeBuff(statConfig.type, value));
+                    statBonus[statConfig.type] += (float)value;
                 }
             }
         }
@@ -320,7 +317,7 @@ namespace XPRising.Systems
                 { BloodType.Scholar, new List<StatConfig>
                 {
                     new(UnitStatType.SpellPower, 0, 0.1),
-                    new(UnitStatType.PrimaryCooldownModifier, 50, 200),
+                    new(UnitStatType.WeaponCooldownRecoveryRate, 50, 0.01),
                     new(UnitStatType.DamageVsDemons, 100, 0.0025)
                 } },
                 { BloodType.VBlood, new List<StatConfig>() },

--- a/Systems/ExperienceSystem.cs
+++ b/Systems/ExperienceSystem.cs
@@ -207,10 +207,11 @@ namespace XPRising.Systems
 
             Equipment equipment = _entityManager.GetComponentData<Equipment>(entity);
             Plugin.Log(LogSystem.Xp, LogLevel.Info, $"Current gear levels: A:{equipment.ArmorLevel.Value} W:{equipment.WeaponLevel.Value} S:{equipment.SpellLevel.Value}");
+            // Brute blood potentially modifies ArmorLevel, so set ArmorLevel 0 and apply the player level to the other stats.
             var halfOfLevel = level / 2f;
-            equipment.ArmorLevel._Value = MathF.Floor(halfOfLevel);
+            equipment.ArmorLevel._Value = 0;
             equipment.WeaponLevel._Value = MathF.Ceiling(halfOfLevel);
-            equipment.SpellLevel._Value = 0;
+            equipment.SpellLevel._Value = MathF.Floor(halfOfLevel);
 
             _entityManager.SetComponentData(entity, equipment);
         }

--- a/Systems/ExperienceSystem.cs
+++ b/Systems/ExperienceSystem.cs
@@ -219,39 +219,15 @@ namespace XPRising.Systems
         /// <summary>
         /// For use with the LevelUpRewards buffing system.
         /// </summary>
-        /// <param name="buffer"></param>
-        /// <param name="owner"></param>
+        /// <param name="statBonus"></param>
         /// <param name="steamID"></param>
-        public static void BuffReceiver(ref LazyDictionary<UnitStatType, float> statBonus, Entity owner, ulong steamID)
+        public static void BuffReceiver(ref LazyDictionary<UnitStatType, float> statBonus, ulong steamID)
         {
             if (!LevelRewardsOn) return;
-            float multiplier = 1;
-            try
-            {
-                // foreach (var gearType in Database.PlayerLevelStats[steamID])
-                // {
-                //     // TODO is this still true?
-                //     //we have to hack unequipped players and give them double bonus because the buffer array does not contain the buff, but they get an additional 
-                //     //buff of the same type when they are equipped! This will make them effectively the same effect, equipped or not.
-                //     //Maybe im just dumb, but I checked the array and tried that approach thinking i was double buffing due to logical error                    
-                //     if (WeaponMasterySystem.GetWeaponType(owner) == WeaponType.None) multiplier = 2; 
-                //
-                //     buffer.Add(new ModifyUnitStatBuff_DOTS()
-                //     {
-                //         StatType = gearType.Key,
-                //         Value = gearType.Value * multiplier,
-                //         ModificationType = ModificationType.AddToBase,
-                //         Id = ModificationId.NewId(0)
-                //     });
-                // }
-                var playerLevel = GetLevel(steamID);
-                var healthBuff = 2f * playerLevel * multiplier;
-                statBonus[UnitStatType.MaxHealth] = healthBuff;
-            }
-            catch (Exception ex)
-            {
-                Plugin.Log(LogSystem.Xp, LogLevel.Error, $"Could not apply XP buff!\n{ex} ");
-            }
+            const float multiplier = 1;
+            var playerLevel = GetLevel(steamID);
+            var healthBuff = 2f * playerLevel * multiplier;
+            statBonus[UnitStatType.MaxHealth] += healthBuff;
         }
 
         public static int ConvertXpToLevel(int xp)

--- a/Utils/AutoSaveSystem.cs
+++ b/Utils/AutoSaveSystem.cs
@@ -252,10 +252,11 @@ namespace XPRising.Utils
             var defaultContents = isJsonListData ? "[]" : "{}";
             try {
                 var saveFile = ConfirmFile(folder, specificFile, defaultContents);
-                var json = File.ReadAllText(saveFile);
-                data = JsonSerializer.Deserialize<TData>(json, JsonOptions);
+                var jsonString = File.ReadAllText(saveFile);
+                data = JsonSerializer.Deserialize<TData>(jsonString, JsonOptions);
                 Plugin.Log(LogSystem.Core, LogLevel.Info, $"Main DB Loaded for {specificFile}");
-                return true;
+                // return false if the saved file only contains the default contents. This allows the default constructors to run.
+                return !defaultContents.Equals(jsonString);
             } catch (Exception e) {
                 Plugin.Log(LogSystem.Core, LogLevel.Error, $"Could not load main {specificFile}: {e.Message}", true);
                 return false;

--- a/Utils/MasteryHelper.cs
+++ b/Utils/MasteryHelper.cs
@@ -225,13 +225,14 @@ public static class MasteryHelper
             case Buffs.Buff_NoBlood_Debuff:
             case Buffs.Buff_General_CurseOfTheForest_Area:
             case Buffs.Buff_General_Silver_Sickness_Burn_Debuff:
+            case Buffs.Buff_General_Garlic_Area_Base:
             case Buffs.Buff_General_Garlic_Area_Inside:
             case Buffs.Buff_General_Garlic_Fever:
             case Buffs.Buff_General_Sludge_Poison:
+            case Buffs.Buff_General_Holy_Area_T01: // Holy aura damage
+            case Buffs.Buff_General_Holy_Area_T02: // Holy aura damage
                 ignore = true;
                 return WeaponMasterySystem.MasteryType.Unarmed;
-            case Buffs.Buff_General_Holy_Area_T01: // [RadialHoly] Healing spell?
-            case Buffs.Buff_General_Holy_Area_T02: // [RadialHoly] Healing spell?
             case Buffs.Buff_General_IgniteLesser: // [Fire] Ignite?
                 return WeaponMasterySystem.MasteryType.Spell;
         }


### PR DESCRIPTION
## [0.1.6] - 2024-05-22

### Added

- `.playerinfo` now also displays the buffs of the given player

### Fixed

- Fix brute blood buff > 30% strength from messing with player levels. It will still add a single level to maintain the bloodline power, but won't change the level more than that.
- DB initialisation/loading will now correctly initialise the data for hardcoded defaults