### PR TITLE
0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.2.2] - 2024-06-24
+
+### Added
+
+- New UnitStats documentation for giving some basic example of stat type bonuses
+
+### Changed
+
+- Greatly reduced many of the default mastery buff stats, as they were way too high.
+
+### Fixed
+
+- Fixed mastery gain not being applied unless mastery logging is turned on
+- Fixed error message in log file if weapon/blood mastery systems are not enabled
+- Changing blood types via blood potions now re-applies the correct blood mastery
+- Level 0 can now correctly gain more than 1 xp per kill
+- Mastery buffs no longer attempt to be applied if the corresponding system is turned off (weapon/blood mastery)
+- Fixed localisation loading to correctly load the data
+
 ## [0.2.1] - 2024-06-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Initial release for 1.0 current in testing. Check the releases page for recent (
 
 - [ChangeLog](CHANGELOG.md)
 - [Command list](Command.md): A full list of commands (when all the systems are configured to be on) can be found here.
-- [System documentation](Documentation.md): Each of the systems has some further documentation on this link. It is worth noting that
-while both the weapon and bloodline mastery systems are intended to provide bonus stats, this is a work in progress and they don't actually provide anything yet.
+- [System documentation](Documentation.md): Each of the systems has some further documentation on this link.
+- [Unit stat documentation](UnitStats.md): A list of stats and their effects that can be used for global mastery configuration.
 
 ## Contributors
 
@@ -37,6 +37,7 @@ while both the weapon and bloodline mastery systems are intended to provide bonu
 - Jason Williams (`SALTYFLEA#3772`)
 - [adainrivers](https://github.com/adainrivers)
 - [Odjit](https://github.com/Odjit)
+- [zfolmt](https://github.com/mfoltz)
 - `Bromelda` and the [BloodCraft](https://discord.gg/aDh98KtEWZ) server
 - `Vex` and the [Vexor World](https://discord.gg/dnVXnHbS) server
 

--- a/UnitStats.md
+++ b/UnitStats.md
@@ -1,0 +1,82 @@
+### Units stats and their effects in V Rising
+The following effects will be applied at 100% mastery. This is some initial investigation, any additional results that you find and can provide will be added to the table.
+
+Note that different weapons will have different damage coefficients. All the damage bonus stats in the table are not normalised, but do seem to work to add some additional damage. Further investigation is required.
+
+| Stat                          | Category  | Value | Effect                                                                     |
+|-------------------------------|-----------|:-----:|----------------------------------------------------------------------------|
+| AttackSpeed                   | offensive |   1   | big cast speed increase (not instant) (cast speed for everything)          |
+| BloodDrain                    | other     |   1   | 1 minute and 40 sec drain on 10 liters of blood                            |
+| BloodEfficiency               | other     |  25   | 500% added (scholar blood 100%)                                            |
+| BonusPhysicalPower            | offensive |   1   | 1 physical power                                                           |
+| BonusSpellPower               | offensive |   1   | 1 spell power                                                              |
+| CCReduction                   | defensive |  50   | half the CC amount (2 sec stun -> 1 sec)                                   |
+| CooldownRecoveryRate          | offensive | 0.15  | minus 1 sec                                                                |
+| DamageReduction               | defensive |  10   | 6 dmg reduction                                                            |
+| DamageVsBeasts                | offensive |   1   | 45 dmg                                                                     |
+| DamageVsCastleObjects         | offensive |   1   | 100% extra (to walls, building, golem before someones in it)               |
+| DamageVsDemons                | offensive |   1   | 21 dmg                                                                     |
+| DamageVsHumans                | offensive |   1   | 22 dmg                                                                     |
+| DamageVsLightArmor            | offensive |       | no data                                                                    |
+| DamageVsMagic                 | offensive |   1   | 29 dmg                                                                     |
+| DamageVsMechanical            | offensive |   1   | 30 dmg                                                                     |
+| DamageVsMineral               | resource  |       | no data                                                                    |
+| DamageVsUndeads               | offensive |   1   | 22 dmg                                                                     |
+| DamageVsVampires              | offensive |   1   | 14 dmg                                                                     |
+| DamageVsVBloods               | offensive |   1   | 27 dmg                                                                     |
+| DamageVsVegetation            | resource  |       | no data                                                                    |
+| DamageVsWood                  | resource  |   1   | increases damage when attacking trees                                      |
+| EnergyGain                    | other     |       | no data[^1]                                                                |
+| FallGravity                   | other     |       | no data[^1]                                                                |
+| FireResistance                | defensive |  10   | 23 dmg reduction per tick                                                  |
+| GarlicResistance              | defensive |  10   | 10 resistance attribute                                                    |
+| HealingReceived               | defensive |  10   | 700 hp per tick (blood rose potion)                                        |
+| HealthRecovery                | defensive |  10   | 2-3 hp per hit (primary attack)                                            |
+| HolyResistance                | defensive |  10   | 2 reduction from holy zones, 5 dmg reduction from mobs                     |
+| ImmuneToHazards               | defensive |  25   | 20 dmg reduction (fire)                                                    |
+| InventorySlots                | other     |       | no data[^1]                                                                |
+| MaxEnergy                     | other     |       | no data[^1]                                                                |
+| MaxHealth                     | defensive |   1   | 1 hp                                                                       |
+| MinionDamage                  | offensive |   1   | 21 dmg (deathknight), 11 dmg (skellies)                                    |
+| MovementSpeed                 | other     |   1   | 1                                                                          |
+| PassiveHealthRegen            | defensive |  0.5  | 583 health/sec (no data on different health pools)                         |
+| PhysicalCriticalStrikeChance  | offensive |  0.1  | 10% increase                                                               |
+| PhysicalCriticalStrikeDamage  | offensive |  0.1  | 10% increase                                                               |
+| PhysicalLifeLeech             | offensive |   1   | 4 health (primary attack) (skills give same health per damage 22dmg=22 hp) |
+| PhysicalPower                 | offensive |   1   | 1 physical power                                                           |
+| PhysicalResistance            | defensive |  0.5  | 21 dmg reduction                                                           |
+| PrimaryAttackSpeed            | offensive |  0.1  | 10% increase                                                               |
+| PrimaryCooldownModifier       | offensive |  30   | immediate attack after combo is over                                       |
+| PrimaryLifeLeech              | offensive |   1   | 210 hp on main attack                                                      |
+| PvPResilience                 | defensive |       | no data                                                                    |
+| Radial_SpellResistance        | defensive |       | no data                                                                    |
+| ReducedResourceDurabilityLoss | other     |       | no data[^2]                                                                |
+| ResistVsBeasts                | defensive |       | no data                                                                    |
+| ResistVsCastleObjects         | defensive |       | no data                                                                    |
+| ResistVsDemons                | defensive |       | no data                                                                    |
+| ResistVsHumans                | defensive |       | no data                                                                    |
+| ResistVsMechanical            | defensive |       | no data                                                                    |
+| ResistVsUndeads               | defensive |       | no data                                                                    |
+| ResistVsVampires              | defensive |  0.5  | 9 dmg reduction (melee), 34 reduction (spell)                              |
+| ResourcePower                 | resource  |   1   | 1 harvesting power                                                         |
+| ResourceYield                 | resource  |  0.1  | 10% extra yield                                                            |
+| ShieldAbsorb                  | defensive |   1   | 84 extra shield                                                            |
+| SiegePower                    | offensive |       | no data                                                                    |
+| SilverCoinResistance          | defensive |       | no data                                                                    |
+| SilverResistance              | defensive |  10   | 10 resistance attribute (no data on actual coin/ore value)                 |
+| SpellCooldownRecoveryRate     | offensive | 0.15  | minus 1 sec                                                                |
+| SpellCriticalStrikeChance     | offensive |  0.1  | 10% increase                                                               |
+| SpellCriticalStrikeDamage     | offensive |  0.1  | 10% increase                                                               |
+| SpellLifeLeech                | offensive |  0.8  | 66 (chaos volley) [^3]                                                     |
+| SpellPower                    | offensive |   1   | 1 spell power                                                              |
+| SpellResistance               | defensive |  0.5  | 34 dmg reduction (shadowbolt)                                              |
+| SunChargeTime                 | defensive |   2   | 2 sec                                                                      |
+| SunResistance                 | defensive |  10   | 10 resistance attribute (20 dmg reduction)                                 |
+| UltimateCooldownRecoveryRate  | offensive |   1   | minus 60 sec                                                               |
+| Vision                        | other     |       | no data[^1]                                                                |
+| WeaponCooldownRecoveryRate    | offensive | 0.15  | minus 1 sec                                                                |
+
+
+[^1]: These stats likely do not work at all
+[^2]: This has direct support in server settings, untested
+[^3]: Different spells do different amounts (have not tested hp/damage)

--- a/XPRising/Hooks/ScriptSpawnServerHook.cs
+++ b/XPRising/Hooks/ScriptSpawnServerHook.cs
@@ -1,0 +1,49 @@
+using System;
+using BepInEx.Logging;
+using HarmonyLib;
+using ProjectM;
+using ProjectM.Shared.Systems;
+using Unity.Collections;
+using XPRising.Systems;
+using XPRising.Utils;
+
+namespace XPRising.Hooks;
+
+[HarmonyPatch]
+public class ScriptSpawnServerHook
+{
+    [HarmonyPatch(typeof(ScriptSpawnServer), nameof(ScriptSpawnServer.OnUpdate))]
+    [HarmonyPrefix]
+    static void OnUpdatePrefix(ScriptSpawnServer __instance)
+    {
+        if (!Plugin.BloodlineSystemActive) return;
+        
+        var entities = __instance.__query_1231292176_0.ToEntityArray(Allocator.Temp);
+        try
+        {
+            foreach (var entity in entities)
+            {
+                var prefabGuid = Helper.GetPrefabGUID(entity);
+                if (prefabGuid != Helper.AppliedBuff &&
+                    Plugin.Server.EntityManager.HasComponent<BloodBuff>(entity) &&
+                    Plugin.Server.EntityManager.TryGetComponentData<EntityOwner>(entity, out var entityOwner) &&
+                    Plugin.Server.EntityManager.TryGetComponentData<PlayerCharacter>(entityOwner, out var playerCharacter))
+                {
+                    if (BloodlineSystem.BuffToBloodTypeMap.TryGetValue(prefabGuid, out var bloodType))
+                    {
+                        Helper.ApplyBuff(playerCharacter.UserEntity, entityOwner, Helper.AppliedBuff);
+                    }
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Plugin.Log(Plugin.LogSystem.Bloodline, LogLevel.Error, $"Error in ScriptSpawnServerHook: {e.Message}", true);
+        }
+        finally
+        {
+            entities.Dispose();
+        }
+    }
+
+}

--- a/XPRising/Systems/BloodlineSystem.cs
+++ b/XPRising/Systems/BloodlineSystem.cs
@@ -5,8 +5,8 @@ using System.Collections.Generic;
 using BepInEx.Logging;
 using Unity.Entities;
 using Stunlock.Core;
-using XPRising.Models;
 using XPRising.Utils;
+using XPRising.Utils.Prefabs;
 using LogSystem = XPRising.Plugin.LogSystem;
 
 namespace XPRising.Systems
@@ -19,6 +19,19 @@ namespace XPRising.Systems
 
         public static double VBloodMultiplier = 15;
         public static double MasteryGainMultiplier = 1.0;
+
+        public static readonly Dictionary<PrefabGUID, GlobalMasterySystem.MasteryType> BuffToBloodTypeMap = new()
+        {
+            { new PrefabGUID((int)Effects.AB_BloodBuff_Worker_IncreaseYield), GlobalMasterySystem.MasteryType.BloodWorker }, // yield bonus
+            { new PrefabGUID((int)Effects.AB_BloodBuff_Warrior_PhysPowerBonus), GlobalMasterySystem.MasteryType.BloodWarrior }, // phys bonus
+            { new PrefabGUID((int)Effects.AB_BloodBuff_Scholar_SpellPowerBonus), GlobalMasterySystem.MasteryType.BloodScholar }, // spell bonus
+            { new PrefabGUID((int)Effects.AB_BloodBuff_Rogue_PhysCritChanceBonus), GlobalMasterySystem.MasteryType.BloodRogue }, // crit bonus
+            { new PrefabGUID((int)Effects.AB_BloodBuff_Mutant_BloodConsumption), GlobalMasterySystem.MasteryType.BloodMutant }, // drain bonus
+            { new PrefabGUID((int)Effects.AB_BloodBuff_Draculin_SpeedBonus), GlobalMasterySystem.MasteryType.BloodDraculin }, // speed bonus
+            { new PrefabGUID((int)Effects.AB_BloodBuff_Dracula_PhysAndSpellPower), GlobalMasterySystem.MasteryType.BloodDracula }, // phys/spell bonus
+            { new PrefabGUID((int)Effects.AB_BloodBuff_Creature_SpeedBonus), GlobalMasterySystem.MasteryType.BloodCreature }, // speed bonus
+            { new PrefabGUID((int)Effects.AB_BloodBuff_PrimaryAttackLifeLeech), GlobalMasterySystem.MasteryType.BloodBrute } // primary life leech
+        };
 
         public static void UpdateBloodline(Entity killer, Entity victim, bool killOnly)
         {
@@ -168,6 +181,8 @@ namespace XPRising.Systems
         private static bool GuidToBloodType(PrefabGUID guid, bool isKiller, out GlobalMasterySystem.MasteryType bloodType)
         {
             bloodType = GlobalMasterySystem.MasteryType.None;
+            if (guid.GuidHash == (int)Remainders.BloodType_VBlood || guid.GuidHash == (int)Remainders.BloodType_GateBoss)
+                return false;
             if(!Enum.IsDefined(typeof(GlobalMasterySystem.MasteryType), guid.GuidHash)) {
                 Plugin.Log(LogSystem.Bloodline, LogLevel.Warning, $"Bloodline not found for guid {guid.GuidHash}. isKiller ({isKiller})", true);
                 return false;

--- a/XPRising/Systems/L10N.cs
+++ b/XPRising/Systems/L10N.cs
@@ -267,7 +267,7 @@ public static class L10N
                 // We need to convert the localisations "leniently" as the TemplateKey enum may have added/removed values.
                 foreach (var (key, localisation) in lenientData.localisations)
                 {
-                    if (Enum.TryParse(key, out TemplateKey keyAsEnum))
+                    if (Enum.TryParse(key, true, out TemplateKey keyAsEnum))
                     {
                         data.localisations.Add(keyAsEnum, localisation);
                     }

--- a/XPRising/Utils/Database.cs
+++ b/XPRising/Utils/Database.cs
@@ -24,13 +24,8 @@ namespace XPRising.Utils
         //-- -- Wanted System
         public static LazyDictionary<ulong, PlayerHeatData> heatCache = new();
 
-        //-- -- Mastery System
-        public static LazyDictionary<ulong, DateTime> player_last_combat = new();
-        public static LazyDictionary<ulong, int> player_combat_ticks = new();
-
         //-- -- Experience System
         public static LazyDictionary<ulong, float> player_level = new();
-        public static LazyDictionary<ulong, Dictionary<UnitStatType, float>> player_geartypedonned = new();
         
         //-- -- Alliance System
         public static LazyDictionary<Entity, Guid> AlliancePlayerToGroupId = new();

--- a/XPRising/Utils/MasteryHelper.cs
+++ b/XPRising/Utils/MasteryHelper.cs
@@ -106,6 +106,7 @@ public static class MasteryHelper
             case Effects.AB_Vampire_Slashers_Primary_Mounted_Hit:
             case Effects.AB_Vampire_Slashers_ElusiveStrike_Dash_PhaseIn:
             case Effects.AB_Vampire_Slashers_ElusiveStrike_Dash_PhaseOut:
+            case Effects.AB_Vampire_Slashers_ElusiveStrike_Dash_PhaseOut_TripleDash:
             case Effects.AB_Blood_VampiricCurse_SlashersLegendary_Buff:
                 return GlobalMasterySystem.MasteryType.WeaponSlasher;
             case Effects.AB_Vampire_Spear_Harpoon_Throw_Projectile:
@@ -196,9 +197,11 @@ public static class MasteryHelper
             case Effects.AB_Illusion_WispDance_Buff01:
             case Effects.AB_Illusion_WispDance_Buff02:
             case Effects.AB_Illusion_WispDance_Buff03:
+            case Effects.AB_Illusion_WispDance_Recast_Projectile:
             // Storm
             case Effects.AB_Storm_EyeOfTheStorm_Throw:
             case Effects.AB_Storm_Discharge_StormShield_Buff_03:
+            case Effects.AB_Storm_Discharge_Spellmod_Recast_AreaImpact:
             case Effects.AB_Storm_BallLightning_Projectile:
             case Effects.AB_Storm_BallLightning_AreaImpact:
             case Effects.AB_Storm_PolarityShift_Projectile:

--- a/XPRising/Utils/Output.cs
+++ b/XPRising/Utils/Output.cs
@@ -18,14 +18,18 @@ namespace XPRising.Utils
 
         public static void DebugMessage(Entity userEntity, string message)
         {
-            var user = Plugin.Server.EntityManager.GetComponentData<User>(userEntity);
-            if (Plugin.IsDebug) ServerChatUtils.SendSystemMessageToClient(Plugin.Server.EntityManager, user, message);
+            if (Plugin.IsDebug && Plugin.Server.EntityManager.TryGetComponentData<User>(userEntity, out var user))
+            {
+                ServerChatUtils.SendSystemMessageToClient(Plugin.Server.EntityManager, user, message);
+            }
         }
         
         public static void DebugMessage(ulong steamID, string message)
         {
-            PlayerCache.FindPlayer(steamID, true, out _, out var userEntity);
-            DebugMessage(userEntity, message);
+            if (Plugin.IsDebug && PlayerCache.FindPlayer(steamID, true, out _, out var userEntity))
+            {
+                DebugMessage(userEntity, message);
+            }
         }
         
         public static void SendMessage(Entity userEntity, L10N.LocalisableString message)


### PR DESCRIPTION
### Added

- New UnitStats documentation for giving some basic example of stat type bonuses

### Changed

- Greatly reduced many of the default mastery buff stats, as they were way too high.

### Fixed

- Fixed mastery gain not being applied unless mastery logging is turned on
- Fixed error message in log file if weapon/blood mastery systems are not enabled
- Changing blood types via blood potions now re-applies the correct blood mastery
- Level 0 can now correctly gain more than 1 xp per kill
- Mastery buffs no longer attempt to be applied if the corresponding system is turned off (weapon/blood mastery)
- Fixed localisation loading to correctly load the data