### PR TITLE
0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.2.3] - 2024-06-26
+
+### Added
+
+- Dracula blood type added to mastery list
+
+### Changed
+
+- All text output by the mod has better support for being resized. Soon to be a user preference instead of a server preference.
+- Localisation changes:
+  - MasteryGainOnKill => removed string substitution sections from template (this is done elsewhere)
+- Blood specific logging has been merged with mastery logging
+- Now has a setting to get V Blood to improve X random blood types, instead of just the current blood. This can be set from 1 random type to all types. Setting this config to 0 will make the V Blood only apply to the current blood type.
+
+### Fixed
+
+- Fixed mastery (weapon and blood) not being applied due to not being logged
+- Fixed percentage stats displayed by `.pb`
+- Improved effectiveness/growth display for mastery
+- Feeding on V Blood now correctly improves blood mastery
+
 ## [0.2.2] - 2024-06-24
 
 ### Added

--- a/Command.md
+++ b/Command.md
@@ -3,7 +3,6 @@ Usage arguments: <> are required, [] are optional
 
 | Command                   | Short hand | Usage                                       | Description                                                                                                                     | Admin | Level |
 |---------------------------|------------|---------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|-------|-------|
-| `.bloodline log`          | `.bl l`    |                                             | Toggles logging of bloodlineXP gain.                                                                                            |   ☐   | `0`   |
 | `.bloodline reset`        | `.bl r`    |                                             | Resets all bloodlines to gain more power with them.                                                                             |   ☐   | `0`   |
 | `.db load`                |            | `[loadBackup]`                              | Force the plugin to load XPRising DB from file. Use loadBackup to load from the backup directory instead of the main directory. |   ☐   | `100` |
 | `.db save`                |            | `[saveBackup]`                              | Force the plugin to write XPRising DB to file. Use saveBackup to additionally save to the backup directory.                     |   ☐   | `100` |

--- a/Documentation.md
+++ b/Documentation.md
@@ -17,7 +17,7 @@ Weapon/spell mastery will increase when the weapon/spell is used to damage a cre
 Feeding on enemies will progress the mastery of that bloodline. If the feeding is cancelled, to kill your victim, a smaller amount of mastery is granted.
 
 Bloodline mastery for blood types that don't match your current blood will still be applied at a greatly reduced amount.
-V Bloods will give increased mastery. They will work for all bloodlines.
+V Bloods will give increased mastery improvements. There is configuration to have this apply to X number of random bloodlines, all bloodlines, or just the current player bloodline.
 
 `Merciless bloodlines` are enabled by default, which means to progress your bloodline's mastery you need to feed on a target with same blood type AND it needs to be blood of higher quality than your bloodline's mastery.
 

--- a/XPRising/Commands/BloodlineCommands.cs
+++ b/XPRising/Commands/BloodlineCommands.cs
@@ -18,20 +18,6 @@ namespace XPRising.Commands
             }
         }
 
-        [Command("log", "l", "", "Toggles logging of bloodlineXP gain.", adminOnly: false)]
-        public static void LogBloodline(ChatCommandContext ctx)
-        {
-            CheckBloodlineSystemActive(ctx);
-            var steamID = ctx.User.PlatformId;
-            var loggingData = Database.PlayerLogConfig[steamID];
-            loggingData.LoggingBloodline = !loggingData.LoggingBloodline;
-            var message = loggingData.LoggingBloodline
-                ? L10N.Get(L10N.TemplateKey.SystemLogEnabled)
-                : L10N.Get(L10N.TemplateKey.SystemLogDisabled);
-            Output.ChatReply(ctx, message.AddField("{system}", "Bloodline system"));
-            Database.PlayerLogConfig[steamID] = loggingData;
-        }
-
         [Command("reset", "r", "", "Resets all bloodlines to gain more power with them.", adminOnly: false)]
         public static void ResetBloodline(ChatCommandContext ctx)
         {

--- a/XPRising/Commands/MasteryCommands.cs
+++ b/XPRising/Commands/MasteryCommands.cs
@@ -86,7 +86,7 @@ namespace XPRising.Commands {
         {
             var name = Enum.GetName(type);
             var mastery = data.Mastery;
-            var effectiveness = GlobalMasterySystem.EffectivenessSubSystemEnabled ? $" (Effectiveness: {data.Effectiveness * 100}%, Growth: {data.Growth * 100}%)" : "";
+            var effectiveness = GlobalMasterySystem.EffectivenessSubSystemEnabled ? $" (E: {data.Effectiveness * 100:F3}%, G: {data.Growth * 100:F3}%)" : "";
             
             return $"{name}: <color={Output.White}>{mastery:F3}%</color>{effectiveness}";
         }
@@ -162,8 +162,8 @@ namespace XPRising.Commands {
         {
             CheckMasteryActive(ctx);
             var steamID = ctx.Event.User.PlatformId;
-            Output.ChatReply(ctx, L10N.Get(L10N.TemplateKey.MasteryReset).AddField("{masteryType}", Enum.GetName(GlobalMasterySystem.MasteryCategory.Weapon)));
             GlobalMasterySystem.ResetMastery(steamID, GlobalMasterySystem.MasteryCategory.Weapon);
+            Output.ChatReply(ctx, L10N.Get(L10N.TemplateKey.MasteryReset).AddField("{masteryType}", Enum.GetName(GlobalMasterySystem.MasteryCategory.Weapon)));
         }
     }
 }

--- a/XPRising/Commands/PlayerInfoCommands.cs
+++ b/XPRising/Commands/PlayerInfoCommands.cs
@@ -127,7 +127,7 @@ namespace XPRising.Commands
             {
                 foreach (var pair in statusBonus)
                 {
-                    var valueString = Helper.percentageStats.Contains(pair.Key) ? $"{pair.Value / 100:F3}%" : $"{pair.Value:F2}";
+                    var valueString = Helper.percentageStats.Contains(pair.Key) ? $"{pair.Value:P2}" : $"{pair.Value:F2}";
                     messages.Add(new L10N.LocalisableString(
                         $"{Helper.CamelCaseToSpaces(pair.Key)}: <color={Output.White}>{valueString}</color>"));
                 }

--- a/XPRising/Configuration/GlobalMasteryConfig.cs
+++ b/XPRising/Configuration/GlobalMasteryConfig.cs
@@ -30,7 +30,8 @@ public static class GlobalMasteryConfig
         WeaponMasterySystem.MasteryGainMultiplier = _configFile.Bind("Mastery - Weapon", "Mastery Gain Multiplier", 1.0, "Multiply the gained mastery value by this amount.").Value;
         
         // Blood mastery specific config
-        BloodlineSystem.MercilessBloodlines = _configFile.Bind("Mastery - Blood", "Merciless Bloodlines", true, "Causes blood mastery to only grow when you kill something with a matching blood type of that has a quality higher than the current blood mastery").Value;
+        BloodlineSystem.MercilessBloodlines = _configFile.Bind("Mastery - Blood", "Merciless Bloodlines", BloodlineSystem.MercilessBloodlines, "Causes blood mastery to only grow when you kill something with a matching blood type of that has a quality higher than the current blood mastery").Value;
+        BloodlineSystem.VBloodAddsXTypes = _configFile.Bind("Mastery - Blood", "V Blood improves X bloodlines", BloodlineSystem.BuffToBloodTypeMap.Count, "Causes consuming a V Blood to improve X random blood masteries. Default value is \"all\" bloodlines. Set to 0 to only do the current bloodline.").Value;
         BloodlineSystem.MasteryGainMultiplier = _configFile.Bind("Mastery - Blood", "Mastery Gain Multiplier", 1.0, "Multiply the gained mastery value by this amount.").Value;
     }
 }

--- a/XPRising/Models/DefaultLocalisations.cs
+++ b/XPRising/Models/DefaultLocalisations.cs
@@ -215,7 +215,7 @@ public static class DefaultLocalisations
             },
             {
                 L10N.TemplateKey.MasteryGainOnKill,
-                $"<color={Output.DarkYellow}>Mastery has changed after kill [ {{masteryType}}: {{currentMastery}}% (<color={Output.Green}>{{masteryChange}}%</color>) ]</color>"
+                $"<color={Output.DarkYellow}>Mastery has changed after kill:</color>"
             },
             {
                 L10N.TemplateKey.MasteryHeader,

--- a/XPRising/Systems/BloodlineSystem.cs
+++ b/XPRising/Systems/BloodlineSystem.cs
@@ -74,15 +74,15 @@ namespace XPRising.Systems
             if (killerBloodType == GlobalMasterySystem.MasteryType.None)
             {
                 Plugin.Log(LogSystem.Bloodline, LogLevel.Info, $"killer has frail blood, not modifying: Killer ({killer}), Victim ({victim})");
-                if (Database.PlayerLogConfig[steamID].LoggingBloodline)
+                if (Database.PlayerLogConfig[steamID].LoggingMastery)
                 {
                     Output.SendMessage(killerUserEntity, L10N.Get(L10N.TemplateKey.BloodlineMercilessErrorBlood));
                 }
                 return;
             }
             
-            var bld = Database.PlayerMastery[steamID];
-            var bloodlineMastery = bld[killerBloodType];
+            var playerMasterydata = Database.PlayerMastery[steamID];
+            var bloodlineMastery = playerMasterydata[killerBloodType];
             growthVal *= bloodlineMastery.Growth;
             
             if (MercilessBloodlines)
@@ -93,7 +93,7 @@ namespace XPRising.Systems
                     {
                         Plugin.Log(LogSystem.Bloodline, LogLevel.Info,
                             $"merciless bloodlines exit: Blood types are different: Killer ({Enum.GetName(killerBloodType)}), Victim ({Enum.GetName(victimBloodType)})");
-                        if (Database.PlayerLogConfig[steamID].LoggingBloodline)
+                        if (Database.PlayerLogConfig[steamID].LoggingMastery)
                         {
                             var message =
                                 L10N.Get(L10N.TemplateKey.BloodlineMercilessUnmatchedBlood);
@@ -106,7 +106,7 @@ namespace XPRising.Systems
                     {
                         Plugin.Log(LogSystem.Bloodline, LogLevel.Info,
                             $"merciless bloodlines exit: victim blood quality less than killer mastery: Killer ({bloodlineMastery.Mastery}), Victim ({victimBloodQuality})");
-                        if (Database.PlayerLogConfig[steamID].LoggingBloodline)
+                        if (Database.PlayerLogConfig[steamID].LoggingMastery)
                         {
                             var message =
                                 L10N.Get(L10N.TemplateKey.BloodlineMercilessErrorWeak);
@@ -139,33 +139,12 @@ namespace XPRising.Systems
                 
                 Plugin.Log(LogSystem.Bloodline, LogLevel.Info, $"Bonus bloodline mastery {bonusMastery:F3}]");
             }
-
-            growthVal *= 0.001 * MasteryGainMultiplier;
             
-            if (Database.PlayerLogConfig[steamID].LoggingBloodline)
-            {
-                if (GlobalMasterySystem.ModMastery(steamID, killerBloodType, growthVal) == 0)
-                {
-                    var currentMastery = Database.PlayerMastery[steamID][killerBloodType].Mastery;
-                    var bloodTypeName = Enum.GetName(killerBloodType);
-                    var message =
-                        L10N.Get(L10N.TemplateKey.MasteryFull)
-                            .AddField("{masteryType}", bloodTypeName)
-                            .AddField("{currentMastery}", $"{currentMastery:F3}");
-                    Output.SendMessage(killerUserEntity, message);
-                }
-                else
-                {
-                    var currentMastery = Database.PlayerMastery[steamID][killerBloodType].Mastery;
-                    var bloodTypeName = Enum.GetName(killerBloodType);
-                    var message =
-                        L10N.Get(L10N.TemplateKey.MasteryGainOnKill)
-                            .AddField("{masteryChange}", $"{growthVal:+##.###;-##.###;0}")
-                            .AddField("{masteryType}", bloodTypeName)
-                            .AddField("{currentMastery}", $"{currentMastery:F3}");
-                    Output.SendMessage(killerUserEntity, message);
-                }
-            }
+            Plugin.Log(LogSystem.Bloodline, LogLevel.Info,
+                () => $"Blood growth {Enum.GetName(killerBloodType)}: [{growthVal:F3} * 0.01 * {MasteryGainMultiplier:F3} => {growthVal * 0.01 * MasteryGainMultiplier:F3}]");
+            growthVal *= 0.05 * MasteryGainMultiplier;
+            
+            GlobalMasterySystem.BankMastery(steamID, victim, killerBloodType, growthVal);
         }
 
         public static GlobalMasterySystem.MasteryType BloodMasteryType(Entity entity)

--- a/XPRising/Systems/GlobalMasterySystem.cs
+++ b/XPRising/Systems/GlobalMasterySystem.cs
@@ -101,6 +101,8 @@ public static class GlobalMasterySystem
         { "dracula", MasteryType.BloodDracula },
         { "draculin", MasteryType.BloodDraculin }
     };
+
+    public static string MasteryGainFormat = $"<color={Output.DarkYellow}>[ {{masteryType}}: {{currentMastery}}% (<color={Output.Green}>{{masteryChange}}%</color>) ]</color>";
     
     private static LazyDictionary<MasteryType, GlobalMasteryConfig.MasteryConfig> _masteryConfig;
     private static List<GlobalMasteryConfig.SkillTree> _skillTrees;
@@ -142,6 +144,10 @@ public static class GlobalMasterySystem
 
         return MasteryCategory.None;
     }
+
+    private const string GenerateFileWarning = "## WARNING: This file is being generated as Mastery Debug logging is enabled.\n" +
+                                               "## This debug file shows the generated contents of the mastery configuration.\n" +
+                                               "## This file is output only and is never read by XPRising.";
     public static bool SetMasteryConfig(GlobalMasteryConfig globalMasteryConfig)
     {
         // Load skill trees
@@ -232,7 +238,7 @@ public static class GlobalMasterySystem
         {
             try
             {
-                AutoSaveSystem.EnsureFile(AutoSaveSystem.ConfigPath, "LoadedGlobalMasteryConfig.json", () => JsonSerializer.Serialize(_masteryConfig, AutoSaveSystem.PrettyJsonOptions));
+                AutoSaveSystem.EnsureFile(AutoSaveSystem.ConfigPath, "LoadedGlobalMasteryConfig.json", () => GenerateFileWarning + JsonSerializer.Serialize(_masteryConfig, AutoSaveSystem.PrettyJsonOptions));
             }
             catch (Exception e)
             {
@@ -259,6 +265,7 @@ public static class GlobalMasterySystem
         {
             var decayValue = decayTicks * masteryConfig.DecayValue;
             var realDecay = ModMastery(steamID, playerMastery, masteryType, -decayValue);
+            Plugin.Log(Plugin.LogSystem.Mastery, LogLevel.Info, $"Player mastery decay: {steamID}: {masteryType}: {realDecay}");
             maxDecayValue = Math.Max(maxDecayValue, realDecay);
         }
         if (maxDecayValue > 0)
@@ -286,31 +293,35 @@ public static class GlobalMasterySystem
         {
             var loggingMastery = Database.PlayerLogConfig[player.steamID].LoggingMastery;
             if (!_masteryBank[player.steamID].TryRemove(targetEntity, out var masteryToStore)) continue;
+            var masteryChanges = new List<L10N.LocalisableString>();
             foreach (var (masteryType, changeInMastery) in masteryToStore)
             {
                 var actualMasteryChange = ModMastery(player.steamID, masteryType, changeInMastery);
-                if (loggingMastery)
+                
+                if (actualMasteryChange == 0)
                 {
-                    if (actualMasteryChange == 0)
-                    {
-                        var currentMastery = Database.PlayerMastery[player.steamID][masteryType].Mastery;
-                        var message =
-                            L10N.Get(L10N.TemplateKey.MasteryFull)
-                                .AddField("{masteryType}", $"{Enum.GetName(masteryType)}")
-                                .AddField("{currentMastery}", $"{currentMastery:F2}");
-                        Output.SendMessage(player.steamID, message);
-                    }
-                    else
-                    {
-                        var currentMastery = Database.PlayerMastery[player.steamID][masteryType].Mastery;
-                        var message =
-                            L10N.Get(L10N.TemplateKey.MasteryGainOnKill)
-                                .AddField("{masteryChange}", $"{actualMasteryChange:+##.###;-##.###;0}")
-                                .AddField("{masteryType}", $"{Enum.GetName(masteryType)}")
-                                .AddField("{currentMastery}", $"{currentMastery:F2}");
-                        Output.SendMessage(player.steamID, message);
-                    }
+                    var currentMastery = Database.PlayerMastery[player.steamID][masteryType].Mastery;
+                    var message =
+                        L10N.Get(L10N.TemplateKey.MasteryFull)
+                            .AddField("{masteryType}", $"{Enum.GetName(masteryType)}")
+                            .AddField("{currentMastery}", $"{currentMastery:F2}");
+                    masteryChanges.Add(message);
                 }
+                else
+                {
+                    var currentMastery = Database.PlayerMastery[player.steamID][masteryType].Mastery;
+                    var message =
+                        new L10N.LocalisableString(MasteryGainFormat)
+                            .AddField("{masteryChange}", $"{actualMasteryChange:+##.###;-##.###;0}")
+                            .AddField("{masteryType}", $"{Enum.GetName(masteryType)}")
+                            .AddField("{currentMastery}", $"{currentMastery:F2}");
+                    masteryChanges.Add(message);
+                }
+            }
+
+            if (loggingMastery && masteryChanges.Count > 0)
+            {
+                Output.SendMessages(player.steamID, L10N.Get(L10N.TemplateKey.MasteryGainOnKill), masteryChanges.ToArray());
             }
         }
     }
@@ -363,8 +374,7 @@ public static class GlobalMasterySystem
                 {
                     var config = _masteryConfig[masteryType];
                     playerMastery[masteryType] = masteryData.ResetMastery(config.MaxEffectiveness, config.GrowthPerEffectiveness);
-                    Plugin.Log(Plugin.LogSystem.Mastery, LogLevel.Info, $"Mastery reset: {Enum.GetName(masteryType)}: {masteryData}");
-                    Output.SendMessage(steamID, L10N.Get(L10N.TemplateKey.MasteryReset).AddField("{masteryType}", Enum.GetName(masteryType)));
+                    Plugin.Log(Plugin.LogSystem.Mastery, LogLevel.Info, $"Mastery reset: {steamID} {Enum.GetName(masteryType)}: {masteryData}");
                 }
                 Database.PlayerMastery[steamID] = playerMastery;
             }

--- a/XPRising/Systems/GlobalMasterySystem.cs
+++ b/XPRising/Systems/GlobalMasterySystem.cs
@@ -133,6 +133,7 @@ public static class GlobalMasterySystem
             case MasteryType.BloodNone:
             case MasteryType.BloodBrute:
             case MasteryType.BloodCreature:
+            case MasteryType.BloodDracula:
             case MasteryType.BloodDraculin:
             case MasteryType.BloodMutant:
             case MasteryType.BloodRogue:

--- a/XPRising/Systems/PermissionSystem.cs
+++ b/XPRising/Systems/PermissionSystem.cs
@@ -73,7 +73,6 @@ namespace XPRising.Systems
             var permissions = new LazyDictionary<string, int>()
             {
                 {"bloodline log", 0},
-                {"bloodline reset", 0},
                 {"db load", 100},
                 {"db save", 100},
                 {"db wipe", 100},

--- a/XPRising/Utils/MasteryHelper.cs
+++ b/XPRising/Utils/MasteryHelper.cs
@@ -90,6 +90,7 @@ public static class MasteryHelper
             case Effects.AB_Pistols_Primary_Attack_VeilOfChaos_Projectile_01:
             case Effects.AB_Pistols_Primary_Attack_VeilOfChaos_Projectile_02:
             case Effects.AB_Pistols_Primary_Attack_VeilOfIllusion_Projectile_01:
+            case Effects.AB_Pistols_Primary_Attack_VeilOfBones_Projectile_01:
                 return GlobalMasterySystem.MasteryType.WeaponPistol;
             case Effects.AB_Vampire_Reaper_HowlingReaper_Hit:
             case Effects.AB_Vampire_Reaper_HowlingReaper_Projectile:


### PR DESCRIPTION
### Added

- Dracula blood type added to mastery list

### Changed

- All text output by the mod has better support for being resized. Soon to be a user preference instead of a server preference.
- Localisation changes:
  - MasteryGainOnKill => removed string substitution sections from template (this is done elsewhere)
- Blood specific logging has been merged with mastery logging
- Now has a setting to get V Blood to improve X random blood types, instead of just the current blood. This can be set from 1 random type to all types. Setting this config to 0 will make the V Blood only apply to the current blood type.

### Fixed

- Fixed mastery (weapon and blood) not being applied due to not being logged
- Fixed percentage stats displayed by `.pb`
- Improved effectiveness/growth display for mastery
- Feeding on V Blood now correctly improves blood mastery