### PR TITLE
v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.3.1] - 2024-08-16
+
+### Changed
+
+- Wanted levels now show a star value in the UI, instead of just the number
+- Mastery gain now takes into account weapon/skill specific attributes to smooth out mastery gain between weapons and spells (for example, the spear skill "A Thousand Spears" will give less mastery per hit than a basic hit from a mace)
+
+### Fixed
+
+- Wanted levels are now shown correctly in the UI (percentage and bar filled)
+- UI messages now no longer continue their timers when not visible
+- Wanted levels now correct update in the UI on player death
+- Fixed display of wanted level colours in the UI
+
 ## [0.3.0] - 2024-08-08
 
 ### Added

--- a/ClientUI/UI/Panel/NotificationPanel.cs
+++ b/ClientUI/UI/Panel/NotificationPanel.cs
@@ -175,6 +175,9 @@ public class NotificationPanel
         // See constants section for timeline
         private void BurstIteration()
         {
+            // Only iterate if this is active (don't progress if the UI is disabled)
+            if (!IsActive) return;
+            
             switch (_burstTimeRemainingMs)
             {
                 case > FadeInEnd:

--- a/ClientUI/UI/Panel/ProgressBar.cs
+++ b/ClientUI/UI/Panel/ProgressBar.cs
@@ -14,7 +14,7 @@ public class ProgressBar
     public const int BaseWidth = 50;
     public const int BarHeight = 22;
 
-    private const int MinLevelWidth = 30;
+    private const int MinHeaderWidth = 30;
 
     private readonly GameObject _contentBase;
     private readonly CanvasGroup _canvasGroup;
@@ -22,7 +22,7 @@ public class ProgressBar
     private readonly LayoutElement _layoutBackground;
     private readonly LayoutElement _layoutFilled;
     private readonly TextMeshProUGUI _tooltipText;
-    private readonly TextMeshProUGUI _levelText;
+    private readonly TextMeshProUGUI _headerText;
     private readonly Image _barImage;
     private readonly TextMeshProUGUI _changeText;
 
@@ -64,14 +64,14 @@ public class ProgressBar
         _highlight = _contentBase.AddComponent<Outline>();
         _highlight.effectColor = Color.black;
 
-        // Split the base bar panel into _levelTxt, progressBarSection and _tooltipTxt
-        _levelText = UIFactory.CreateLabel(_contentBase, "levelText", "");
-        UIFactory.SetLayoutElement(_levelText.gameObject, minWidth: MinLevelWidth, minHeight: BarHeight,
-            preferredHeight: BarHeight, preferredWidth: MinLevelWidth);
+        // Split the base bar panel into _headerTxt, progressBarSection and _tooltipTxt
+        _headerText = UIFactory.CreateLabel(_contentBase, "HeaderText", "");
+        UIFactory.SetLayoutElement(_headerText.gameObject, minWidth: MinHeaderWidth, minHeight: BarHeight,
+            preferredHeight: BarHeight, preferredWidth: MinHeaderWidth);
 
         var progressBarSection = UIFactory.CreateHorizontalGroup(_contentBase, "ProgressBarSection", false, true,
             true, true, 0, default, Colour.PanelBackground);
-        UIFactory.SetLayoutElement(progressBarSection, minWidth: BaseWidth - MinLevelWidth, minHeight: BarHeight,
+        UIFactory.SetLayoutElement(progressBarSection, minWidth: BaseWidth - MinHeaderWidth, minHeight: BarHeight,
             flexibleWidth: 10000);
 
         var progressFilled = UIFactory.CreateUIObject("ProgressFilled", progressBarSection);
@@ -93,7 +93,7 @@ public class ProgressBar
         tooltipRect.anchorMax = Vector2.one;
         
         // Add some change text. Positioning to be updated, but it should be outside the regular layout
-        _changeText = UIFactory.CreateLabel(_levelText.gameObject, "ChangeText", "", alignment: TextAlignmentOptions.MidlineRight, color: Colour.Highlight);
+        _changeText = UIFactory.CreateLabel(_headerText.gameObject, "ChangeText", "", alignment: TextAlignmentOptions.MidlineRight, color: Colour.Highlight);
         UIFactory.SetLayoutElement(_changeText.gameObject, ignoreLayout: true);
         _changeText.gameObject.AddComponent<Outline>();
         _changeText.overflowMode = TextOverflowModes.Overflow;
@@ -118,12 +118,12 @@ public class ProgressBar
         _timer.Stop();
     }
     
-    public void SetProgress(float progress, string level, string tooltip, ActiveState activeState, Color colour,
+    public void SetProgress(float progress, string header, string tooltip, ActiveState activeState, Color colour,
         string changeText, bool flash)
     {
         _layoutBackground.flexibleWidth = 1.0f - progress;
         _layoutFilled.flexibleWidth = progress;
-        _levelText.text = level;
+        _headerText.text = header;
         _tooltipText.text = tooltip;
         _barImage.color = colour;
         _changeText.text = changeText;
@@ -179,6 +179,9 @@ public class ProgressBar
     // See constants section for timeline
     private void AlertIteration()
     {
+        // Only iterate if this is active (don't progress if the UI is disabled)
+        if (!IsActive) return;
+        
         switch (_alertTimeRemainingMs)
         {
             case > FlashPulseEndsMs:

--- a/ClientUI/UI/Panel/ProgressBarPanel.cs
+++ b/ClientUI/UI/Panel/ProgressBarPanel.cs
@@ -58,7 +58,7 @@ public class ProgressBarPanel
         
         var validatedProgress = Math.Clamp(data.ProgressPercentage, 0f, 1f);
         var colour = Colour.ParseColour(data.Colour, validatedProgress);
-        progressBar.SetProgress(validatedProgress, $"{data.Level:D2}", $"{data.Tooltip} ({validatedProgress:P})", data.Active, colour, data.Change, data.Flash);
+        progressBar.SetProgress(validatedProgress, data.Header, $"{data.Tooltip} ({validatedProgress:P})", data.Active, colour, data.Change, data.Flash);
 
         // TODO work out how/when this should happen
         // if (data.Change != "")

--- a/XPRising/Hooks/DealDamageSystemHook.cs
+++ b/XPRising/Hooks/DealDamageSystemHook.cs
@@ -52,9 +52,9 @@ public class DealDamageSystemDealDamagePatch
                 var hasMovement = __instance.EntityManager.HasComponent<Movement>(damageEvent.Target);
                 if (hasStats && hasLevel && hasMovement)
                 {
-                    var masteryValue = damageEvent.MainType == MainDamageType.Physical
-                        ? victimStats.PhysicalPower.Value
-                        : victimStats.SpellPower.Value;
+                    var skillMultiplier = damageEvent.MainFactor > 0 ? damageEvent.MainFactor : 1f;
+                    var masteryValue =
+                        MathF.Max(victimStats.PhysicalPower.Value, victimStats.SpellPower.Value) * skillMultiplier;
                     WeaponMasterySystem.UpdateMastery(sourceUser.PlatformId, masteryType, masteryValue, damageEvent.Target);
                 }
                 else
@@ -75,7 +75,8 @@ public class DealDamageSystemDealDamagePatch
             () =>
                 $"{prefix}Source: {GetName(em, source, out _)} -> " +
                 $"({DebugTool.GetPrefabName(damageEvent.SpellSource)}) -> " +
-                $"{GetName(em, damageEvent.Target, out _)}", forceLog);
+                $"{GetName(em, damageEvent.Target, out _)}" +
+                $"[Multiplier: {damageEvent.MainFactor}]", forceLog);
     }
 
     private static string GetName(EntityManager em, Entity entity, out bool isUser)

--- a/XPRising/Transport/ClientActionHandler.cs
+++ b/XPRising/Transport/ClientActionHandler.cs
@@ -132,7 +132,7 @@ public static class ClientActionHandler
         if (!Cache.PlayerClientUICache[user.PlatformId]) return;
         
         var changeText = change == 0 ? "" : $"{change:+##.###;-##.###;0}";
-        XPShared.Transport.Utils.ServerSetBarData(user, "XPRising.XP", "XP", level, progressPercent, $"XP: {earned}/{needed}", ActiveState.Active, XpColour, changeText);
+        XPShared.Transport.Utils.ServerSetBarData(user, "XPRising.XP", "XP", $"{level:D2}", progressPercent, $"XP: {earned}/{needed}", ActiveState.Active, XpColour, changeText);
     }
 
     public static void SendMasteryData(User user, GlobalMasterySystem.MasteryType type, float mastery,
@@ -150,7 +150,7 @@ public static class ClientActionHandler
             Group = $"XPRising.{GlobalMasterySystem.GetMasteryCategory(type)}",
             Label = $"{type}",
             ProgressPercentage = mastery*0.01f,
-            Level = (int)mastery,
+            Header = $"{(int)mastery:D2}",
             Tooltip = $"{type} mastery",
             Active = activeState,
             Colour = colour,
@@ -166,12 +166,19 @@ public static class ClientActionHandler
         if (!Cache.PlayerClientUICache[user.PlatformId]) return;
         
         var heatIndex = FactionHeat.GetWantedLevel(heat);
-        var baseHeat = heatIndex > 0 ? FactionHeat.HeatLevels[heatIndex - 1] : 0;
-        var percentage = (float)(heat - baseHeat) / FactionHeat.HeatLevels[heatIndex];
-        var activeState = heat > 0 ? ActiveState.Active : ActiveState.NotActive;
-        var colour1 = heatIndex > 0 ? FactionHeat.ColourGradient[heatIndex - 1] : "white";
-        var colour2 = FactionHeat.ColourGradient[heatIndex];
-        XPShared.Transport.Utils.ServerSetBarData(user, "XPRising.heat", $"{faction}", heatIndex, percentage, $"Faction {faction}", activeState, $"@{colour1}@{colour2}");
+        if (heatIndex == FactionHeat.HeatLevels.Length)
+        {
+            XPShared.Transport.Utils.ServerSetBarData(user, "XPRising.heat", $"{faction}", $"{heatIndex:D}★", 1f, $"Faction {faction}", ActiveState.Active, $"#{FactionHeat.ColourGradient[heatIndex - 1]}");
+        }
+        else
+        {
+            var baseHeat = heatIndex > 0 ? FactionHeat.HeatLevels[heatIndex - 1] : 0;
+            var percentage = (float)(heat - baseHeat) / (FactionHeat.HeatLevels[heatIndex] - baseHeat);
+            var activeState = heat > 0 ? ActiveState.Active : ActiveState.NotActive;
+            var colour1 = heatIndex > 0 ? $"#{FactionHeat.ColourGradient[heatIndex - 1]}" : "white";
+            var colour2 = $"#{FactionHeat.ColourGradient[heatIndex]}";
+            XPShared.Transport.Utils.ServerSetBarData(user, "XPRising.heat", $"{faction}", $"{heatIndex:D}★", percentage, $"Faction {faction}", activeState, $"@{colour1}@{colour2}");
+        }
     }
     
     private static readonly Dictionary<ulong, FrameTimer> FrameTimers = new();

--- a/XPRising/Utils/Output.cs
+++ b/XPRising/Utils/Output.cs
@@ -55,20 +55,20 @@ namespace XPRising.Utils
             }
         }
         
-        public static void SendMessage(Entity userEntity, L10N.LocalisableString message)
+        public static void SendMessage(Entity userEntity, L10N.LocalisableString message, string colourOverride = "")
         {
             if (!Plugin.Server.EntityManager.TryGetComponentData<User>(userEntity, out var user)) return;
 
             var preferences = Database.PlayerPreferences[user.PlatformId];
-            SendMessage(user, message, preferences, LogLevel.Info);
+            SendMessage(user, message, preferences, LogLevel.Info, colourOverride);
         }
         
-        public static void SendMessage(ulong steamID, L10N.LocalisableString message)
+        public static void SendMessage(ulong steamID, L10N.LocalisableString message, string colourOverride = "")
         {
             if (!PlayerCache.FindPlayer(steamID, true, out _, out _, out var user)) return;
             
             var preferences = Database.PlayerPreferences[user.PlatformId];
-            SendMessage(user, message, preferences, LogLevel.Info);
+            SendMessage(user, message, preferences, LogLevel.Info, colourOverride);
         }
 
         public static void SendMessages(ulong steamID, L10N.LocalisableString header, L10N.LocalisableString[] messages)

--- a/XPShared/BloodstoneExtensions/ClientChat.cs
+++ b/XPShared/BloodstoneExtensions/ClientChat.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using HarmonyLib;
 using ProjectM.Network;
 using ProjectM.UI;

--- a/XPShared/BloodstoneExtensions/MessageUtils.cs
+++ b/XPShared/BloodstoneExtensions/MessageUtils.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using BepInEx.Logging;
 using Bloodstone.API;
 using ProjectM;

--- a/XPShared/Transport/Messages/ProgressSerialisedMessage.cs
+++ b/XPShared/Transport/Messages/ProgressSerialisedMessage.cs
@@ -13,7 +13,7 @@ public class ProgressSerialisedMessage : VNetworkChatMessage
     
     public string Group = "";
     public string Label = "";
-    public int Level = 0;
+    public string Header = "";
     public float ProgressPercentage = 0f;
     public string Tooltip = "";
     public ActiveState Active = ActiveState.Unchanged;
@@ -25,7 +25,7 @@ public class ProgressSerialisedMessage : VNetworkChatMessage
     {
         writer.Write(Group);
         writer.Write(Label);
-        writer.Write(Level);
+        writer.Write(Header);
         writer.Write(ProgressPercentage);
         writer.Write(Tooltip);
         writer.Write((int)Active);
@@ -38,7 +38,7 @@ public class ProgressSerialisedMessage : VNetworkChatMessage
     {
         Group = reader.ReadString();
         Label = reader.ReadString();
-        Level = reader.ReadInt32();
+        Header = reader.ReadString();
         ProgressPercentage = reader.ReadSingle();
         Tooltip = reader.ReadString();
         Active = (ActiveState)reader.ReadInt32();

--- a/XPShared/Transport/Utils.cs
+++ b/XPShared/Transport/Utils.cs
@@ -7,14 +7,14 @@ namespace XPShared.Transport;
 
 public static class Utils
 {
-    public static void ServerSetBarData(User playerCharacter, string barGroup, string bar, int level, float progressPercentage, string tooltip, ProgressSerialisedMessage.ActiveState activeState, string colour, string change = "")
+    public static void ServerSetBarData(User playerCharacter, string barGroup, string bar, string header, float progressPercentage, string tooltip, ProgressSerialisedMessage.ActiveState activeState, string colour, string change = "")
     {
         var msg = new ProgressSerialisedMessage()
         {
             Group = barGroup,
             Label = bar,
             ProgressPercentage = progressPercentage,
-            Level = level,
+            Header = header,
             Tooltip = tooltip,
             Active = activeState,
             Colour = colour,


### PR DESCRIPTION
### Changed

- Wanted levels now show a star value in the UI, instead of just the number
- Mastery gain now takes into account weapon/skill specific attributes to smooth out mastery gain between weapons and spells (for example, the spear skill "A Thousand Spears" will give less mastery per hit than a basic hit from a mace)

### Fixed

- Wanted levels are now shown correctly in the UI (percentage and bar filled)
- UI messages now no longer continue their timers when not visible
- Wanted levels now correct update in the UI on player death
- Fixed display of wanted level colours in the UI