### PR TITLE
v0.3.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-quality: 'preview'
           
       - name: After dotnet setup
         run: dotnet --info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,15 +12,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
 
-    steps:
-#      - name: Setup .NET
-#        uses: actions/setup-dotnet@v4
-#        with:
-#          dotnet-version: '8.0.x'
-          
-      - name: After dotnet setup
-        run: dotnet --info
-          
+    steps:  
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v1.1.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '6.0.x'
-          dotnet-quality: 'preview'
           
       - name: After dotnet setup
         run: dotnet --info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
-          dotnet-quality: 'preview'
           
       - name: After dotnet setup
         run: dotnet --info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '8.0.x'
+#      - name: Setup .NET
+#        uses: actions/setup-dotnet@v4
+#        with:
+#          dotnet-version: '8.0.x'
           
       - name: After dotnet setup
         run: dotnet --info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
+          dotnet-version: '8'
           dotnet-quality: 'preview'
           
       - name: After dotnet setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ jobs:
           dotnet-version: '6.0.x'
           dotnet-quality: 'preview'
           
+      - name: After dotnet setup
+        run: dotnet --info
+          
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v1.1.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8'
+          dotnet-version: '8.0.x'
           dotnet-quality: 'preview'
           
       - name: After dotnet setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.3.8] - 2024-10-13
+
+### Fixed
+
+- Ensure units spawned with a lifetime of a multiple of 10 (and no decimal value) do not trigger attempting to spawn them at level 0. Internal support for spawning wanted units at level 0 has been dropped to help make sure this is the case (and spawning units at level 0 would rarely ever be useful in practise).
+
 ## [0.3.7] - 2024-10-03
 
 ### Fixed

--- a/XPRising/Utils/SpawnUnit.cs
+++ b/XPRising/Utils/SpawnUnit.cs
@@ -15,7 +15,8 @@ public class SpawnUnit {
     }
     
     // Encodes the unit level/faction into the lifetime
-    // Set faction/level to 0 to spawn the unit with the default faction/level
+    // Set faction to 0 to spawn the unit with the default faction.
+    // When the level is set to 0, this will spawn it as a default unit.
     // Encoded as: 99F.LLCC
     // where:
     //    F = faction
@@ -28,8 +29,8 @@ public class SpawnUnit {
         lifetime = Math.Clamp((lifetime / 10) * 10, 10, 1000);
         // Faction needs to be between 0 and 9
         var factionAsInt = Math.Clamp((int)faction, 0, 9);
-        // Level needs to be between 0 and 99
-        level = Math.Clamp(level, 0, 99);
+        // Level needs to be between 1 and 99
+        level = Math.Clamp(level, 1, 99);
 	
         // Adds level and level "checksum" - this assumes a level cap of 99
         var partFaction = factionAsInt; // section: 10X
@@ -55,6 +56,11 @@ public class SpawnUnit {
         encodedSection = (encodedSection % 1) * 100;
         decoded = (int)encodedSection;
         level = decoded;
+
+        // We should not decode this value in the following circumstances:
+        // - lifetime is greater than our max encoded value
+        // - level is 0
+        if (lifetime > 1000 || level == 0) return false;
 
         // Get 2 digits for the level check
         encodedSection = (encodedSection % 1) * 100;


### PR DESCRIPTION
### Fixed

- Ensure units spawned with a lifetime of a multiple of 10 (and no decimal value) do not trigger attempting to spawn them at level 0. Internal support for spawning wanted units at level 0 has been dropped to help make sure this is the case (and spawning units at level 0 would rarely ever be useful in practise).