### PR TITLE
v0.4.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,16 @@ jobs:
 
       - name: Publish XPRising.ClientUI to Thunderstore
         run: tcli publish --config-path ./ClientUI/thunderstore.toml --token ${{ secrets.THUNDERSTORE_KEY }} --file ./dist/XPRising-ClientUI-${RELEASE_TAG:1}.zip
-        
+  
+  update_latest_release:
+    # required to allow release to be updated
+    permissions:
+      contents: write
+    env:
+      RELEASE_TAG: ${{ github.event.inputs.tag_name || github.event.release.tag_name }}
+    runs-on: ubuntu-latest
+    
+    steps:
       - name: Set release as latest
         run: gh release edit ${{ env.RELEASE_TAG }} --draft=false --latest
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.4.10] - 2025-06-04
+
+### Added
+
+- Added support for allowing all mastery gain to reduce as mastery increase (separate from prestige mechanics). The `Mastery Gain Reduction` configuration option in `GlobalMasteryConfig.cfg` can be used to allow a linear mastery gain (across 0-100%) to having the mastery gain reduced to 0 as the mastery reaches 100%.
+
+### Fixed
+
+- Fixed XP gain on mobs that should get 0 XP
+- Updated support for ambush mobs so that Bloodcraft will treat them as normal mobs and give an appropriate amount of XP
+
 ## [0.4.9] - 2025-05-30
 
 ### Changed

--- a/XPRising/Configuration/GlobalMasteryConfig.cs
+++ b/XPRising/Configuration/GlobalMasteryConfig.cs
@@ -26,6 +26,9 @@ public static class GlobalMasteryConfig
         GlobalMasterySystem.DecaySubSystemEnabled = _configFile.Bind("Global Mastery", "Enable Decay Subsystem", false, "Enables the Decay Mastery subsystem. This will decay mastery over time. Decay rate is set via 'globalMasteryConfig.json'").Value;
         GlobalMasterySystem.MasteryThreshold = _configFile.Bind("Global Mastery", "Mastery Threshold", 0.0, "Threshold level the mastery must reach before the mastery can be reset.").Value;
         GlobalMasterySystem.DecayInterval = _configFile.Bind("Global Mastery", "Decay Tick Interval", 60, "Amount of seconds per decay tick.").Value;
+        var gainReduction = _configFile.Bind("Global Mastery", "Mastery Gain Reduction", 0f, "Used to change the mastery gain from linear to quadratic. This will reduce the mastery gain as mastery approaches 100%.\n" +
+            "Value is clamped from 0 to 100. Set to 0 to have a linear mastery gain. Set to 100 to reduce mastery gain to 0 as mastery approaches 100%.").Value;
+        GlobalMasterySystem.MasteryGainReductionMultiplier = Math.Clamp(gainReduction, 0, 100)*0.000001;
 
         // Weapon mastery specific config
         WeaponMasterySystem.MasteryGainMultiplier = _configFile.Bind("Mastery - Weapon", "Mastery Gain Multiplier", 1.0, "Multiply the gained mastery value by this amount.").Value;

--- a/XPRising/Systems/ExperienceSystem.cs
+++ b/XPRising/Systems/ExperienceSystem.cs
@@ -95,6 +95,8 @@ namespace XPRising.Systems
         public static void ExpMonitor(List<Alliance.ClosePlayer> closeAllies, PrefabGUID victimPrefab, int victimLevel, bool isVBlood)
         {
             var multiplier = ExpValueMultiplier(victimPrefab, isVBlood);
+            // Early exit to entirely stop XP calculations when the multiplier is 0.
+            if (multiplier == 0) return;
             
             var sumGroupLevel = closeAllies.Sum(x => x.playerLevel);
             var avgGroupLevel = (int)Math.Floor(closeAllies.Average(x => x.playerLevel));

--- a/XPRising/Systems/GlobalMasterySystem.cs
+++ b/XPRising/Systems/GlobalMasterySystem.cs
@@ -26,6 +26,7 @@ public static class GlobalMasterySystem
     public static bool DecaySubSystemEnabled = false;
     public static bool SpellMasteryRequiresUnarmed = false;
     public static int DecayInterval = 60;
+    public static double MasteryGainReductionMultiplier = 0f;
     public static readonly string CustomPreset = "custom";
     public const string NonePreset = "none";
     
@@ -410,7 +411,9 @@ public static class GlobalMasterySystem
     {
         var mastery = playerMastery[type];
         var currentMastery = mastery.Mastery;
-        mastery.Mastery += mastery.CalculateBaseMasteryGrowth(changeInMastery);
+        // Calculate a potential reduction in mastery gain. This should result in a value [1,0]
+        var masteryGainReductionMultiplier = (1 - currentMastery * currentMastery * MasteryGainReductionMultiplier);
+        mastery.Mastery += mastery.CalculateBaseMasteryGrowth(changeInMastery) * masteryGainReductionMultiplier;
         playerMastery[type] = mastery;
         
         // Calculating it this way, rather than using the result of `CalculateBaseMasteryGrowth` as `Mastery()` clamps the result appropriately so we can't go over max


### PR DESCRIPTION
### Added

- Added support for allowing all mastery gain to reduce as mastery increase (separate from prestige mechanics). The `Mastery Gain Reduction` configuration option in `GlobalMasteryConfig.cfg` can be used to allow a linear mastery gain (across 0-100%) to having the mastery gain reduced to 0 as the mastery reaches 100%.

### Fixed

- Fixed XP gain on mobs that should get 0 XP
- Updated support for ambush mobs so that Bloodcraft will treat them as normal mobs and give an appropriate amount of XP